### PR TITLE
v2 compatible version of toHaveStyleRule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 const toMatchStyledComponentsSnapshot = require('./matchers/toMatchStyledComponentsSnapshot')
 const toHaveStyleRule = require('./matchers/toHaveStyleRule')
 const styleSheetSerializer = require('./serializers/styleSheetSerializer')
+const styleSheet = require('styled-components/lib/models/StyleSheet')
+const { isOverV2, isServer } = require('./utils')
+
+if (isOverV2()) {
+  styleSheet.default.reset(isServer())
+}
 
 expect.addSnapshotSerializer(styleSheetSerializer)
 expect.extend({ toMatchStyledComponentsSnapshot, toHaveStyleRule })

--- a/src/matchers/toHaveStyleRule.js
+++ b/src/matchers/toHaveStyleRule.js
@@ -3,7 +3,8 @@ const {
   printReceived,
   printExpected,
 } = require('jest-matcher-utils')
-const { styleSheet } = require('styled-components')
+const styleSheet = require('styled-components/lib/models/StyleSheet')
+const { getCSS } = require('../utils')
 
 /**
  * Finds the generated class name from a rendered StyledComponent.
@@ -46,7 +47,7 @@ const findClassName = (received) => {
 const toHaveStyleRule = (received, selector, value) => {
   try {
     const className = findClassName(received)
-    const css = styleSheet.styleSheet.tags[0].innerHTML
+    const css = getCSS(styleSheet)
     const styles = new RegExp(`${className} {([^}]*)`, 'g').exec(css)
     const capture = new RegExp(`${selector}:[\s]*([^;]+)`, 'g')
 

--- a/src/serializers/styleSheetSerializer.js
+++ b/src/serializers/styleSheetSerializer.js
@@ -1,15 +1,6 @@
 const css = require('css')
 const styleSheet = require('styled-components/lib/models/StyleSheet')
-const { ServerStyleSheet } = require('styled-components')
-
-// styled-components >=2.0.0
-const isOverV2 = Boolean(ServerStyleSheet)
-
-const isServer = typeof document === 'undefined'
-
-if (isOverV2) {
-  styleSheet.default.reset(isServer)
-}
+const { getCSS } = require('../utils')
 
 const getClassNames = (node, classNames) => {
   if (node.children && node.children.reduce) {
@@ -49,17 +40,7 @@ const getMediaQueries = (ast, filter) => (
 )
 
 const getStyles = (classNames) => {
-  let styles
-  const styleTags = /<style[^>]*>([\s\S]*)<\/style>/
-
-  if (isOverV2 && isServer) {
-    styles = new ServerStyleSheet().getStyleTags().match(styleTags)[1]
-  } else if (isOverV2) {
-    styles = styleSheet.default.instance.toHTML().match(styleTags)[1]
-  } else {
-    styles = styleSheet.rules().map(rule => rule.cssText).join('\n')
-  }
-
+  const styles = getCSS(styleSheet)
   const ast = css.parse(styles)
   const filter = filterNodes(classNames)
   const rules = ast.stylesheet.rules.filter(filter)

--- a/src/serializers/styleSheetSerializer.js
+++ b/src/serializers/styleSheetSerializer.js
@@ -1,6 +1,16 @@
 const css = require('css')
 const styleSheet = require('styled-components/lib/models/StyleSheet')
 const { ServerStyleSheet } = require('styled-components')
+const StyleSheet = require('styled-components/lib/models/StyleSheet')
+
+// styled-components >=2.0.0
+const isOverV2 = Boolean(ServerStyleSheet)
+
+const isServer = typeof document === 'undefined'
+
+if (isOverV2) {
+  StyleSheet.default.reset(isServer)
+}
 
 const getClassNames = (node, classNames) => {
   if (node.children && node.children.reduce) {
@@ -40,9 +50,17 @@ const getMediaQueries = (ast, filter) => (
 )
 
 const getStyles = (classNames) => {
-  const styles = ServerStyleSheet
-    ? new ServerStyleSheet().getStyleTags().match(/<style[^>]*>([\s\S]*)<\/style>/)[1]
-    : styleSheet.rules().map(rule => rule.cssText).join('\n')
+  let styles
+  const styleTags = /<style[^>]*>([\s\S]*)<\/style>/
+
+  if (isOverV2 && isServer) {
+    styles = new ServerStyleSheet().getStyleTags().match(styleTags)[1]
+  } else if (isOverV2) {
+    styles = StyleSheet.default.instance.toHTML().match(styleTags)[1]
+  } else {
+    styles = styleSheet.rules().map(rule => rule.cssText).join('\n')
+  }
+
   const ast = css.parse(styles)
   const filter = filterNodes(classNames)
   const rules = ast.stylesheet.rules.filter(filter)

--- a/src/serializers/styleSheetSerializer.js
+++ b/src/serializers/styleSheetSerializer.js
@@ -1,7 +1,6 @@
 const css = require('css')
 const styleSheet = require('styled-components/lib/models/StyleSheet')
 const { ServerStyleSheet } = require('styled-components')
-const StyleSheet = require('styled-components/lib/models/StyleSheet')
 
 // styled-components >=2.0.0
 const isOverV2 = Boolean(ServerStyleSheet)
@@ -9,7 +8,7 @@ const isOverV2 = Boolean(ServerStyleSheet)
 const isServer = typeof document === 'undefined'
 
 if (isOverV2) {
-  StyleSheet.default.reset(isServer)
+  styleSheet.default.reset(isServer)
 }
 
 const getClassNames = (node, classNames) => {
@@ -56,7 +55,7 @@ const getStyles = (classNames) => {
   if (isOverV2 && isServer) {
     styles = new ServerStyleSheet().getStyleTags().match(styleTags)[1]
   } else if (isOverV2) {
-    styles = StyleSheet.default.instance.toHTML().match(styleTags)[1]
+    styles = styleSheet.default.instance.toHTML().match(styleTags)[1]
   } else {
     styles = styleSheet.rules().map(rule => rule.cssText).join('\n')
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,29 @@
+const { ServerStyleSheet } = require('styled-components')
+
+const STYLE_TAGS_REGEXP = /<style[^>]*>([\s\S]*)<\/style>/
+
+// styled-components >=2.0.0
+function isOverV2() {
+  return Boolean(ServerStyleSheet)
+}
+
+module.exports.isOverV2 = isOverV2
+
+function isServer() {
+  return typeof document === 'undefined'
+}
+
+module.exports.isServer = isServer
+
+function getCSS(styleSheet) {
+  const overV2 = isOverV2()
+  if (overV2 && isServer()) {
+    return new ServerStyleSheet().getStyleTags().match(STYLE_TAGS_REGEXP)[1]
+  }
+  if (overV2) {
+    return styleSheet.default.instance.toHTML().match(STYLE_TAGS_REGEXP)[1]
+  }
+  return styleSheet.rules().map(rule => rule.cssText).join('\n')
+}
+
+module.exports.getCSS = getCSS

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,11 +1,7 @@
-/**
- * @jest-environment node
- */
-
 import React from 'react'
 import renderer from 'react-test-renderer'
 import styled from 'styled-components'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import '../src'
 
 const Wrapper = styled.section`
@@ -52,4 +48,14 @@ test('enzyme', () => {
   )
 
   expect(tree).toMatchStyledComponentsSnapshot()
+})
+
+test('toHaveStyleRule', () => {
+  const tree = mount(
+    <Wrapper>
+      <Title>Hello World, this is my first styled component!</Title>
+    </Wrapper>,
+  )
+
+  expect(tree).toHaveStyleRule('background', 'papayawhip')
 })


### PR DESCRIPTION
Based on my [previous PR](https://github.com/styled-components/jest-styled-components/pull/24).
Basically now just reads the stylesheet CSS the "v2 way" (I created a reusable function for reading the css on different styled-components versions). Didn't test the native version of `toHaveStyleRule` so it might just be that it still needs a bit of work.

https://github.com/styled-components/jest-styled-components/pull/14#issuecomment-306690511