### PR TITLE
Fix stylesheet style matching

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const { ServerStyleSheet } = require('styled-components')
 
-const STYLE_TAGS_REGEXP = /<style[^>]*>([\s\S]*)<\/style>/
+const STYLE_TAGS_REGEXP = /<(\/)?style[^>]*>/g
 
 // styled-components >=2.0.0
 function isOverV2() {
@@ -18,10 +18,10 @@ module.exports.isServer = isServer
 function getCSS(styleSheet) {
   const overV2 = isOverV2()
   if (overV2 && isServer()) {
-    return new ServerStyleSheet().getStyleTags().match(STYLE_TAGS_REGEXP)[1]
+    return new ServerStyleSheet().getStyleTags().replace(STYLE_TAGS_REGEXP, '')
   }
   if (overV2) {
-    return styleSheet.default.instance.toHTML().match(STYLE_TAGS_REGEXP)[1]
+    return styleSheet.default.instance.toHTML().replace(STYLE_TAGS_REGEXP, '')
   }
   return styleSheet.rules().map(rule => rule.cssText).join('\n')
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -3,13 +3,13 @@
 exports[`toMatchSnapshot null 1`] = `null`;
 
 exports[`toMatchSnapshot shallow 1`] = `
-.iATjrR {
+.gzMTbA {
   padding: 4em;
   background: papayawhip;
 }
 
 <section
-  className="sc-bdVaJa iATjrR"
+  className="sc-bwzfXH gzMTbA"
 >
   <styled.h1>
     Hello World, this is my first styled component!
@@ -18,40 +18,52 @@ exports[`toMatchSnapshot shallow 1`] = `
 `;
 
 exports[`toMatchSnapshot test-renderer 1`] = `
-.iATjrR {
+.gzMTbA {
   padding: 4em;
   background: papayawhip;
 }
 
-.dMjUoH {
+.jASgrB {
   font-size: 1.5em;
   -webkit-text-align: center;
   text-align: center;
   color: palevioletred;
 }
 
-.dMjUoH:hover {
+.jASgrB:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.dMjUoH em {
+.jASgrB em {
   color: green;
 }
 
 @media (min-width: 600px) {
-  .dMjUoH {
+  .jASgrB {
     color: blue;
   }
 }
 
 <section
-  className="sc-bdVaJa iATjrR"
+  className="sc-bwzfXH gzMTbA"
 >
   <h1
-    className="sc-bwzfXH dMjUoH"
+    className="sc-htpNat jASgrB"
   >
     Hello World, this is my first styled component!
   </h1>
 </section>
+`;
+
+exports[`toMatchSnapshot when horizontal must be display:inline 1`] = `
+<styled.div
+  horizontal={true}
+>
+  <div
+    className="sc-bdVaJa huqire"
+  >
+    text
+  </div>
+</styled.div>
 `;

--- a/test/components/StyledLabel.js
+++ b/test/components/StyledLabel.js
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+
+export default styled.div`
+  position: relative;
+  display: ${({ horizontal }) => horizontal ? 'inline' : 'block'};
+`

--- a/test/components/index.js
+++ b/test/components/index.js
@@ -1,0 +1,3 @@
+import StyledLabel from './StyledLabel'
+
+export { StyledLabel }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,6 +3,7 @@ import renderer from 'react-test-renderer'
 import styled from 'styled-components'
 import { shallow, mount } from 'enzyme'
 import '../src'
+import { StyledLabel } from './components'
 
 const Wrapper = styled.section`
   padding: 4em;
@@ -13,7 +14,6 @@ const Title = styled.h1`
   font-size: 1.5em;
   text-align: center;
   color: palevioletred;
-
   &:hover {
     text-decoration: underline;
   }
@@ -51,6 +51,15 @@ describe('toMatchSnapshot', () => {
 
     expect(tree).toMatchStyledComponentsSnapshot()
   })
+
+  test('when horizontal must be display:inline', () => {
+    // given
+    const text = 'text'
+    // when
+    const component = mount(<StyledLabel horizontal>{text}</StyledLabel>)
+    // then
+    expect(component).toMatchStyledComponentsSnapshot()
+  })
 })
 
 describe('toHaveStyleRule', () => {
@@ -64,5 +73,14 @@ describe('toHaveStyleRule', () => {
     const tree = mount(<Wrapper />)
 
     expect(tree).toHaveStyleRule('background', 'papayawhip')
+  })
+
+  test('when horizontal must be display:inline', () => {
+    // given
+    const text = 'text'
+    // when
+    const component = mount(<StyledLabel horizontal>{text}</StyledLabel>)
+    // then
+    expect(component).toHaveStyleRule('display', 'inline')
   })
 })


### PR DESCRIPTION
I'm still a bit unsure what causes the problems, but in some cases SC uses multiple style tags to render the styles. In some cases (https://github.com/styled-components/jest-styled-components/issues/26) it seems that it's also possible for a stylesheet to not have style tags at all.
One possible reason for not having styles at all would be having 2 instances of styled-components running. This happened to me when I `yarn link`ed this library to my actual project.

I tried to write a test case that would cause 2 style tags to appear, but with no luck. I basically tried everything from a component with keyframes to having >1000 components. Maybe someone with a bit more knowledge about the internals of SC could elaborate.

This pull request should at least fix the exceptions being thrown, but it might be possible to end up with some weird test results.