### PR TITLE
Performance improvement getClassNames

### DIFF
--- a/src/serializers/styleSheetSerializer.js
+++ b/src/serializers/styleSheetSerializer.js
@@ -1,20 +1,6 @@
 const css = require('css')
 const styleSheet = require('styled-components/lib/models/StyleSheet')
-const { getCSS } = require('../utils')
-
-const getClassNames = (node, classNames) => {
-  if (node.children && node.children.reduce) {
-    classNames = node.children.reduce((acc, child) => (
-      acc.concat(getClassNames(child, acc))
-    ), classNames)
-  }
-
-  if (node.props && node.props.className) {
-    return classNames.concat(node.props.className.split(' '))
-  }
-
-  return classNames
-}
+const { getCSS, getClassNames } = require('../utils')
 
 const filterNodes = classNames => (rule) => {
   if (rule.type === 'rule') {

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ module.exports.getCSS = getCSS
 function getClassNames (node, classNames) {
   if (node.children && node.children.reduce) {
     classNames = node.children.reduce((acc, child) => (
-      acc.concat(getClassNames(child, acc))
+      acc.concat(getClassNames(child, []))
     ), classNames)
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,3 +27,19 @@ function getCSS(styleSheet) {
 }
 
 module.exports.getCSS = getCSS
+
+function getClassNames (node, classNames) {
+  if (node.children && node.children.reduce) {
+    classNames = node.children.reduce((acc, child) => (
+      acc.concat(getClassNames(child, acc))
+    ), classNames)
+  }
+
+  if (node.props && node.props.className) {
+    return classNames.concat(node.props.className.split(' '))
+  }
+
+  return classNames
+}
+
+module.exports.getClassNames = getClassNames

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,23 @@
+const { getClassNames } = require('../src/utils')
+
+describe('getClassNames', () => {
+  test('gets list of unique classes from a tree', () => {
+    const tree = {
+      props: {
+        className: 'one'
+      },
+      children: [
+        {
+          props: { className: 'two' },
+        },
+        {
+          props: { className: 'three' },
+        }
+      ]
+    }
+
+    const got = getClassNames(tree, []).sort()
+    const expected = ['one', 'two', 'three'].sort()
+    expect(got).toEqual(expected)
+  })
+})


### PR DESCRIPTION
It might be hard to tell in the diff, this is the line that changed:
`acc.concat(getClassNames(child, []))`

I thought of another solution that uses `push` instead of `concat` to save memory, not sure if it's necessary though... so I'll just open this PR for meow

EDIT:

This was happening until I made the change in this PR

```
 FAIL  ./storyshots.test.js (10.358s)
  ● Storyshots › ReactSwagger › default

    RangeError: Invalid array length

      at Object.test (node_modules/@storybook/addon-storyshots/dist/test-bodies.js:22:18)
      at Object.<anonymous> (node_modules/@storybook/addon-storyshots/dist/index.js:147:25)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
      at process._tickCallback (internal/process/next_tick.js:109:7)

  ● Storyshots › ReactSwagger › no title

    RangeError: Invalid array length

      at Object.test (node_modules/@storybook/addon-storyshots/dist/test-bodies.js:22:18)
      at Object.<anonymous> (node_modules/@storybook/addon-storyshots/dist/index.js:147:25)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
      at process._tickCallback (internal/process/next_tick.js:109:7)

  Storyshots
    ReactSwagger
      ✕ default (6864ms)
      ✕ no title (2718ms)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
Snapshots:   0 total
Time:        10.423s, estimated 11s
Ran all test suites.

Watch Usage: Press w to show more.
```