### PR TITLE
fix: support html with multiple style tags

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const { ServerStyleSheet } = require('styled-components')
 
-const STYLE_TAGS_REGEXP = /<style[^>]*>([\s\S]*)<\/style>/
+const STYLE_TAGS_REGEXP = /<style[^>]*>([^<]*)</g
 
 // styled-components >=2.0.0
 function isOverV2() {
@@ -15,14 +15,23 @@ function isServer() {
 
 module.exports.isServer = isServer
 
+function parseCSSfromHTML (html) {
+  let css = ''
+  let matches
+  while ((matches = STYLE_TAGS_REGEXP.exec(html)) !== null) {
+    css += matches[1].trim()
+  }
+  return css
+}
+
+module.exports.parseCSSfromHTML = parseCSSfromHTML
+
 function getCSS(styleSheet) {
   const overV2 = isOverV2()
   if (overV2 && isServer()) {
-    const matches = new ServerStyleSheet().getStyleTags().match(STYLE_TAGS_REGEXP)
-    return matches ? matches[1] : ''
+    return parseCSSfromHTML(new ServerStyleSheet().getStyleTags())
   } else if (overV2) {
-    const matches = styleSheet.default.instance.toHTML().match(STYLE_TAGS_REGEXP)
-    return matches ? matches[1] : ''
+    return parseCSSfromHTML(styleSheet.default.instance.toHTML())
   }
 
   return styleSheet.rules().map(rule => rule.cssText).join('\n')

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,4 +1,29 @@
-const { getClassNames } = require('../src/utils')
+const { parseCSSfromHTML, getClassNames } = require('../src/utils')
+
+describe('parseCSSfromHTML', () => {
+  test('returns empty string when there is no style tag', () => {
+    expect(parseCSSfromHTML('<html></html>')).toBe('')
+  })
+
+  test('returns the css from the style tag', () => {
+    const css = `.something { color: red; }`
+    const html = `<style type="text/css"
+      data-styled-components="iATjrR bIftVI"
+      data-styled-components-is-local="true"
+    >
+      ${css}
+    </style>`
+
+    expect(parseCSSfromHTML(html)).toBe(css)
+  })
+
+  test('returns the css when there are multiple style tags', () => {
+    const css = `.something { color: red; }`
+    const otherCss = `.other-thing { color: pink; }`
+    expect(parseCSSfromHTML(`<style>${css}</style><style>${otherCss}</style>`))
+      .toBe(css + otherCss)
+  })
+})
 
 describe('getClassNames', () => {
   test('produces a list of unique class names from a tree', () => {


### PR DESCRIPTION
Hello, it's me :)

Unfortunately I can't show the example I have of this bug with actual components (it's in a closed source project) and it's not super trivial to replicate.

When parsing the styles from the html if there were multiple style tags, the regex would capture
everything between the first opening <style> tag and the last closing
</style> tag

Because of this I was getting the following error:

```
  ● Storyshots › Button › default

    undefined:1:97: missing '{'

      at Object.styledSnapshot [as test]
(src/components/storyshots.spec.js:10:16)
      at Object.<anonymous>
(node_modules/@storybook/addon-storyshots/dist/index.js:147:25)
      at Promise.resolve.then.el (node_modules/p-map/index.js:42:16)
```

EDIT: I got the regex by adapting it from this stack overflow post: https://stackoverflow.com/questions/3790681/regular-expression-to-remove-html-tags/3790726#3790726