### PR TITLE
Added support to external classes references

### DIFF
--- a/src/styleSheetSerializer.js
+++ b/src/styleSheetSerializer.js
@@ -1,7 +1,12 @@
 const css = require('css')
-const { getCSS } = require('./utils')
+const { getCSS, getClassHashes } = require('./utils')
 
 const getClassNames = node => {
+  const rules = getCSS().stylesheet.rules
+    .filter(item => item.type === 'rule')
+    .map(item => item.selectors)
+    .reduce((a, item) => a.concat(item), [])
+    .concat(getClassHashes())
   let classNames = new Set()
 
   if (node.children) {
@@ -15,7 +20,10 @@ const getClassNames = node => {
   }
 
   if (node.props && node.props.className) {
-    classNames = new Set([...node.props.className.split(/\s/), ...classNames])
+    const itemClassNames = node.props.className
+      .split(/\s/)
+      .filter(item => rules.some(a => a.indexOf(item) > -1))
+    classNames = new Set(itemClassNames.concat([...classNames]))
   }
 
   return classNames

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@ const { ServerStyleSheet } = require('styled-components')
 const StyleSheet = require('styled-components/lib/models/StyleSheet')
 
 const STYLE_TAGS_REGEXP = /<style[^>]*>([^<]*)</g
+const CLASS_HASH_REGEXP = /data-styled-components=["']?((?:.(?!["']?\s+(?:\S+)=|[>"']))+.)["']?/
 
 const isOverV2 = () => Boolean(ServerStyleSheet)
 
@@ -25,15 +26,26 @@ const getStyle = html => {
   return style
 }
 
+const getHTML = () => {
+  if (isServer()) {
+    return new ServerStyleSheet().getStyleTags()
+  }
+  return StyleSheet.default.instance.toHTML()
+}
+
+const getClassHashes = () => {
+  const hashes = getHTML().match(CLASS_HASH_REGEXP)
+  if (hashes && hashes.length > 1) {
+    return hashes[1].split(/\s/)
+  }
+  return []
+}
+
 const getCSS = () => {
   let style
 
   if (isOverV2()) {
-    if (isServer()) {
-      style = getStyle(new ServerStyleSheet().getStyleTags())
-    } else {
-      style = getStyle(StyleSheet.default.instance.toHTML())
-    }
+    style = getStyle(getHTML())
   } else {
     style = StyleSheet.rules().map(rule => rule.cssText).join('\n')
   }
@@ -45,4 +57,5 @@ module.exports = {
   resetStyleSheet,
   getStyle,
   getCSS,
+  getClassHashes,
 }

--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -67,7 +67,7 @@ exports[`attaching additional props - mount 1`] = `
 
 <styled.div>
   <div
-    className="c0"
+    className="div c0"
   />
 </styled.div>
 `;
@@ -78,7 +78,7 @@ exports[`attaching additional props - react-test-renderer 1`] = `
 }
 
 <div
-  className="c0"
+  className="div c0"
 />
 `;
 
@@ -88,7 +88,7 @@ exports[`attaching additional props - shallow 1`] = `
 }
 
 <div
-  className="c0"
+  className="div c0"
 />
 `;
 
@@ -455,6 +455,22 @@ exports[`referring to other components - react-test-renderer 1`] = `
   >
     Hovering my parent changes my style!
   </span>
+</a>
+`;
+
+exports[`support className references - mount 1`] = `
+<a
+  className="link-item"
+>
+  Lorem ipsum
+</a>
+`;
+
+exports[`support className references - react-test-renderer 1`] = `
+<a
+  className="link-item"
+>
+  Lorem ipsum
 </a>
 `;
 

--- a/test/styleSheetSerializer.spec.js
+++ b/test/styleSheetSerializer.spec.js
@@ -223,3 +223,14 @@ test('referring to other components', () => {
     'referring to other components - mount'
   )
 })
+
+test('supporting external class references', () => {
+  const component = <a className="link-item">Lorem ipsum</a>
+
+  expect(renderer.create(component).toJSON()).toMatchSnapshot(
+    'support className references - react-test-renderer'
+  )
+  expect(mount(component)).toMatchSnapshot(
+    'support className references - mount'
+  )
+})


### PR DESCRIPTION
As described in the title, this PR adresses the issue faced on #49

- Reads css and classes metadata in order to preserve placeholder classes declared on `className` attributes
- Added tests for this new use case

@MicheleBertoli let me know what you think 😊 I'd love to have this fixed in the upstream package