### PR TITLE
Test style rules with media queries options

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ The first argument is the expected property, the second is the expected value (s
 test('it works', () => {
   const tree = renderer.create(<Button />).toJSON()
   expect(tree).toHaveStyleRule('color', 'red')
+  // with media queries support (web only)
+  expect(tree).toHaveStyleRule('color', 'red', {media: '(max-width: 768px)'})
 })
 ```
 

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -13,10 +13,14 @@ const notToHaveStyleRule = (component, property, value) => {
   expect(mount(component)).not.toHaveStyleRule(property, value)
 }
 
-const toHaveStyleRule = (component, property, value) => {
-  expect(renderer.create(component).toJSON()).toHaveStyleRule(property, value)
-  expect(shallow(component)).toHaveStyleRule(property, value)
-  expect(mount(component)).toHaveStyleRule(property, value)
+const toHaveStyleRule = (component, property, value, options) => {
+  expect(renderer.create(component).toJSON()).toHaveStyleRule(
+    property,
+    value,
+    options
+  )
+  expect(shallow(component)).toHaveStyleRule(property, value, options)
+  expect(mount(component)).toHaveStyleRule(property, value, options)
 }
 
 test('null', () => {
@@ -115,4 +119,32 @@ test('theming', () => {
     'mediumseagreen'
   )
   expect(mount(component)).toHaveStyleRule('color', 'mediumseagreen')
+})
+
+test('media queries', () => {
+  const Text = styled.a`
+    font-size: 2em;
+    color: white;
+    @media (max-width: 640px) {
+      font-size: 1.5em;
+    }
+    @media (max-width: 1080px) {
+      font-size: 1em;
+    }
+    @media (min-width: 480px) and (max-width: 920px) {
+      color: black;
+    }
+  `
+
+  toHaveStyleRule(<Text>Text with styles</Text>, 'font-size', '2em')
+  toHaveStyleRule(<Text>Text with styles</Text>, 'color', 'white')
+  toHaveStyleRule(<Text>Text with styles</Text>, 'font-size', '1.5em', {
+    media: '(max-width: 640px)',
+  })
+  toHaveStyleRule(<Text>Text with styles</Text>, 'font-size', '1em', {
+    media: '(max-width: 1080px)',
+  })
+  toHaveStyleRule(<Text>Text with styles</Text>, 'color', 'black', {
+    media: '(min-width: 480px) and (max-width: 920px)',
+  })
 })


### PR DESCRIPTION
@MicheleBertoli 
As to https://github.com/styled-components/jest-styled-components/issues/52
Enhancements to support media queries rules is here. I tried to use less code as possible :grinning:. Don't know if you have better patterns on checking the options (I don't know if you like using objects to define functions to handle or else :joy:). For now it looks clean, but if other more options (like finding rules for ```:hover``` as mentioned further in the issue is implemented. 

Also using options as mention earlier like ```{ media: { 'max-width': '768px' } }``` may not be easy. It requires more work, I read the css parser docs and it doesn't parse the media syntax :joy:. So maybe right now just use simple strings to match media rules, because it could easily support multiple rules too like ```(min-width: 480px) and (max-width: 920px)```

If its ok, then I should add some documentation 👍 