### PR TITLE
Pseudo selectors support

### DIFF
--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -1,5 +1,8 @@
 const { getCSS } = require('./utils')
 
+const hasAtRule = options =>
+  Object.keys(options).some(option => ['media', 'supports'].includes(option))
+
 const getClassNames = received => {
   let className
 
@@ -17,8 +20,12 @@ const getClassNames = received => {
   return className ? className.split(/\s/) : []
 }
 
-const hasClassNames = (classNames, selectors) =>
-  classNames.some(className => selectors.includes(`.${className}`))
+const hasClassNames = (classNames, selectors, options) =>
+  classNames.some(className =>
+    selectors.includes(
+      `.${className}${options.pseudo ? `${options.pseudo}` : ''}`
+    )
+  )
 
 const getAtRules = (ast, options) =>
   Object.keys(options)
@@ -33,9 +40,12 @@ const getAtRules = (ast, options) =>
     .reduce((acc, rules) => acc.concat(rules), [])
 
 const getRules = (ast, classNames, options) => {
-  const rules = options ? getAtRules(ast, options) : ast.stylesheet.rules
+  const rules = hasAtRule(options)
+    ? getAtRules(ast, options)
+    : ast.stylesheet.rules
   return rules.filter(
-    rule => rule.type === 'rule' && hasClassNames(classNames, rule.selectors)
+    rule =>
+      rule.type === 'rule' && hasClassNames(classNames, rule.selectors, options)
   )
 }
 
@@ -55,7 +65,7 @@ const die = (utils, property) => ({
   message: `Property not found: ${utils.printReceived(property)}`,
 })
 
-function toHaveStyleRule(received, property, value, options) {
+function toHaveStyleRule(received, property, value, options = {}) {
   const classNames = getClassNames(received)
   const ast = getCSS()
   const rules = getRules(ast, classNames, options)

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -23,7 +23,7 @@ const getClassNames = received => {
 const hasClassNames = (classNames, selectors, options) =>
   classNames.some(className =>
     selectors.includes(
-      `.${className}${options.pseudo ? `${options.pseudo}` : ''}`
+      `.${className}${options.modifier ? `${options.modifier}` : ''}`
     )
   )
 

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -140,3 +140,55 @@ test('at rules', () => {
     supports: '(display: flexbox)',
   })
 })
+
+test('pseudo selectors', () => {
+  const Link = styled.a`
+    color: white;
+    &:hover {
+      color: blue;
+    }
+    &::after {
+      content: 'Hello';
+      color: red;
+    }
+  `
+
+  toHaveStyleRule(<Link />, 'color', 'white')
+  toHaveStyleRule(<Link />, 'color', 'blue', {
+    pseudo: ':hover',
+  })
+  toHaveStyleRule(<Link />, 'content', "'Hello'", {
+    pseudo: '::after',
+  })
+  toHaveStyleRule(<Link />, 'color', 'red', {
+    pseudo: '::after',
+  })
+})
+
+test('option combinations', () => {
+  const Link = styled.a`
+    &:hover {
+      color: black;
+    }
+    @media (max-width: 640px) {
+      &:hover {
+        color: blue;
+      }
+      &::before {
+        content: 'Hello';
+      }
+    }
+  `
+
+  toHaveStyleRule(<Link />, 'color', 'black', {
+    pseudo: ':hover',
+  })
+  toHaveStyleRule(<Link />, 'color', 'blue', {
+    media: '(max-width: 640px)',
+    pseudo: ':hover',
+  })
+  toHaveStyleRule(<Link />, 'content', "'Hello'", {
+    media: '(max-width: 640px)',
+    pseudo: '::before',
+  })
+})

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -141,27 +141,29 @@ test('at rules', () => {
   })
 })
 
-test('pseudo selectors', () => {
+test('selector modifiers', () => {
   const Link = styled.a`
     color: white;
     &:hover {
       color: blue;
     }
     &::after {
-      content: 'Hello';
       color: red;
+    }
+    &[href*="somelink.com"] {
+      color: green;
     }
   `
 
   toHaveStyleRule(<Link />, 'color', 'white')
   toHaveStyleRule(<Link />, 'color', 'blue', {
-    pseudo: ':hover',
-  })
-  toHaveStyleRule(<Link />, 'content', "'Hello'", {
-    pseudo: '::after',
+    modifier: ':hover',
   })
   toHaveStyleRule(<Link />, 'color', 'red', {
-    pseudo: '::after',
+    modifier: '::after',
+  })
+  toHaveStyleRule(<Link />, 'color', 'green', {
+    modifier: '[href*="somelink.com"]',
   })
 })
 
@@ -174,21 +176,23 @@ test('option combinations', () => {
       &:hover {
         color: blue;
       }
-      &::before {
-        content: 'Hello';
+    }
+    @supports (display: flexbox) {
+      &[href*="somelink.com"] {
+        color: green;
       }
     }
   `
 
   toHaveStyleRule(<Link />, 'color', 'black', {
-    pseudo: ':hover',
+    modifier: ':hover',
   })
   toHaveStyleRule(<Link />, 'color', 'blue', {
     media: '(max-width: 640px)',
-    pseudo: ':hover',
+    modifier: ':hover',
   })
-  toHaveStyleRule(<Link />, 'content', "'Hello'", {
-    media: '(max-width: 640px)',
-    pseudo: '::before',
+  toHaveStyleRule(<Link />, 'color', 'green', {
+    supports: '(display: flexbox)',
+    modifier: '[href*="somelink.com"]',
   })
 })


### PR DESCRIPTION
@MicheleBertoli I manage to get it done with your help for the hasClassNames function. Thanks 😃 
- When getting rules, it needs to distinguish whether the options includes a At rule or not. I added a ```hasAtRule``` function for checking (Not known if this should be in utils.js?). The array containing at rules value should be easily added for checking, but right now can we just keep it simple? (I think most users would be using media rules. 😂 )
- Letting the user to pass colon symbols in the pseudo option makes it dynamically for users that like single, or double colons.
- Now, we can accomplish combinations At rules and pseudo selectors. 👍 
- I have to take back the option default as empty object as undefined will break at ```hasAtRule``` function