### PR TITLE
Jest 21.0.0 compatibility: Make message in matchers a function

### DIFF
--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -62,7 +62,7 @@ const getDeclarations = (rules, property) =>
 
 const die = (utils, property) => ({
   pass: false,
-  message: `Property not found: ${utils.printReceived(property)}`,
+  message: () => `Property not found: ${utils.printReceived(property)}`,
 })
 
 function toHaveStyleRule(received, property, value, options = {}) {
@@ -87,7 +87,7 @@ function toHaveStyleRule(received, property, value, options = {}) {
       ? value.test(declaration.value)
       : value === declaration.value
 
-  const message =
+  const message = () =>
     `Expected ${property}${pass ? ' not ' : ' '}to match:\n` +
     `  ${this.utils.printExpected(value)}\n` +
     'Received:\n' +

--- a/test/__snapshots__/toHaveStyleRule.spec.js.snap
+++ b/test/__snapshots__/toHaveStyleRule.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`message when property not found 1`] = `"Property not found: [31m\\"a\\"[39m"`;
+
+exports[`message when value does not match 1`] = `
+"Expected background to match:
+  [32m\\"red\\"[39m
+Received:
+  [31m\\"orange\\"[39m"
+`;

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -23,12 +23,27 @@ const toHaveStyleRule = (component, property, value, options) => {
   expect(mount(component)).toHaveStyleRule(property, value, options)
 }
 
+test('message when property not found', () => {
+  expect(() => expect(null).toHaveStyleRule('a')).toThrowErrorMatchingSnapshot()
+})
+
 test('null', () => {
   expect(null).not.toHaveStyleRule('a', 'b')
 })
 
 test('non-styled', () => {
   notToHaveStyleRule(<div />, 'a', 'b')
+})
+
+test('message when value does not match', () => {
+  const Wrapper = styled.section`background: orange;`
+
+  expect(() => {
+    expect(renderer.create(<Wrapper />).toJSON()).toHaveStyleRule(
+      'background',
+      'red'
+    )
+  }).toThrowErrorMatchingSnapshot()
 })
 
 test('basic', () => {


### PR DESCRIPTION
Jest 21.0.0 and above expect `result.message` to be a function.

See https://github.com/facebook/jest/pull/3972 (commit facebook/jest@b3d944e)