### PR TITLE
Rewrite toHaveStyleRule for React Native

### DIFF
--- a/src/native/toHaveStyleRule.js
+++ b/src/native/toHaveStyleRule.js
@@ -1,81 +1,32 @@
-const parse = require('styled-components/lib/vendor/postcss-safe-parser/parse')
-
 function toHaveStyleRule(component, name, expected) {
-  const { rules } = component.type()
-  const props = component.props()
-  const ast = parse(rules.join())
+  const styles = component.props.style.filter(x => x)
 
   /**
-   * Fail by default
+   * Convert style name to camel case (so we can compare)
    */
-  let pass = false
+  const camelCasedName = name.replace(/-(\w)/, (_, match) =>
+    match.toUpperCase()
+  )
 
   /**
-   * There can be two cases:
-   * - rule (dynamic property, value is a function of props)
-   * - decl (static property, value is a string)
-   *
-   * We also take the last matched node because
-   * developer may override initial assignment
+   * Merge all styles into one final style object and search for the desired
+   * stylename against this object
    */
-  const node = ast.nodes
-    .filter(n => {
-      switch (n.type) {
-        case 'rule':
-          return n.selector.indexOf(name) === 0
-        case 'decl':
-          return n.prop === name
-        default:
-          return false
-      }
-    })
-    .pop()
+  const mergedStyles = styles.reduce((acc, item) => ({ ...acc, ...item }), {})
+  const received = mergedStyles[camelCasedName]
+  const pass = received === expected
 
-  let received
-
-  /**
-   * If node is not found (typo in the rule name /
-   * rule isn't specified for component), we return
-   * a special message
-   */
-  if (!node) {
+  if (!received) {
     const error = `${name} isn't in the style rules`
     return {
       message: () =>
         `${this.utils.matcherHint('.toHaveStyleRule')}\n\n` +
-        `Expected ${component.name()} to have a style rule:\n` +
+        `Expected ${component.type} to have a style rule:\n` +
         `  ${this.utils.printExpected(`${name}: ${expected}`)}\n` +
         'Received:\n' +
         `  ${this.utils.printReceived(error)}`,
       pass: false,
     }
-  }
-
-  /**
-   * In a case of declaration, it's fairly easy to check if expected === given
-   */
-  if (node.type === 'decl') {
-    pass = node.value === expected
-    received = node.value
-    /**
-   * But in case of rule we have quite some complexity here:
-   * We can't get a ref to the function using `postcss-safe-parser`, so
-   * we have to construct it by ourselves. We also don't know how user called `props`
-   * in his value function, so we parse the entire CSS block to match its params and body
-   *
-   * Once params are matched, we construct a new function and
-   * invoke it with props, taken from the enzyme
-   */
-  } else {
-    const match = node.source.input.css.match(
-      new RegExp(`${name}:.*,function (.*){(.*)},`)
-    )
-    const param = match[1].slice(1, -1)
-    /* eslint-disable */
-    const fn = Function(param, match[2])
-    /* eslint-enable */
-    received = fn(props)
-    pass = received === expected
   }
 
   const diff =
@@ -87,10 +38,10 @@ function toHaveStyleRule(component, name, expected) {
   const message = pass
     ? () =>
         `${this.utils.matcherHint('.not.toHaveStyleRule')}\n\n` +
-        `Expected ${component.name()} not to contain:\n${diff}`
+        `Expected ${component.type} not to contain:\n${diff}`
     : () =>
         `${this.utils.matcherHint('.toHaveStyleRule')}\n\n` +
-        `Expected ${component.name()} to have a style rule:\n${diff}`
+        `Expected ${component.type} to have a style rule:\n${diff}`
 
   return { message, pass }
 }


### PR DESCRIPTION
Closes https://github.com/styled-components/jest-styled-components/issues/76

Hi @MicheleBertoli!

So, I finally got some time to work on #76 🙂 After talking a look on list of changes, I decided to rewrite the matcher. Previously, it was parsing given AST etc, but now, with the new version, it doesn't seem to be needed (:tada:). 

As far as we get all styles pre-calculated, their names are converted to camelCase. In order to keep the matcher signature (and make transition painless), I convert given kebab-case names to camelCase under the hood. 

Besides that, from now on we can't use component names (so instead of fancy `Foo` component, it'll give back `View`).

---
Anyway, I hope you like the PR and it'll be a good improvement to existing codebase ;)