### PR TITLE
Update enzyme-to-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.0.0",
-    "enzyme-to-json": "^3.0.1",
+    "enzyme-to-json": "^3.3.0",
     "eslint": "^3.17.1",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",

--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -8,9 +8,7 @@ exports[`any component - mount 1`] = `
 
 <div>
   <Link>
-    <a
-      className={undefined}
-    >
+    <a>
       Unstyled, boring Link
     </a>
   </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,9 +1836,9 @@ enzyme-adapter-utils@^1.0.0:
     object.assign "^4.0.4"
     prop-types "^15.5.10"
 
-enzyme-to-json@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.1.4.tgz#a4a85a8f7b561cb8c9c0d728ad1b619a3fed7df2"
+enzyme-to-json@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.0.tgz#553e23a09ffb4b0cf09287e2edf9c6539fddaa84"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
v3.3.0 allows support for React 16.2.0 fragments (https://github.com/adriantoine/enzyme-to-json/releases/tag/v3.3.0).

I figured this does not need an issue before I opened the PR.