### PR TITLE
Upgrade to styled-components v3 and use secret internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ test('it works', () => {
 })
 ```
 
-The matcher supports a third `options` parameter which makes it possible to search for rules nested within an [At-rule](https://developer.mozilla.org/en/docs/Web/CSS/At-rule) ([media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media) and [supports](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)) or to add modifiers to the class selector. This feature is supported in React only, and more options are coming soon.
+The matcher supports a third `options` parameter which makes it possible to search for rules nested within an [At-rule](https://developer.mozilla.org/en/docs/Web/CSS/At-rule) ([media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media)) or to add modifiers to the class selector. This feature is supported in React only, and more options are coming soon.
 
 ```js
 const Button = styled.button`
@@ -314,7 +314,7 @@ const Button = styled.button`
 test('it works', () => {
   const tree = renderer.create(<Button />).toJSON()
   expect(tree).toHaveStyleRule('color', 'red', {
-    media: '(max-width: 640px)',
+    media: '(max-width:640px)',
     modifier: ':hover',
   })
 })

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "react-dom": "^16.0.0",
     "react-native": "^0.49.3",
     "react-test-renderer": "^16.0.0",
-    "styled-components": "^2.1.1"
+    "styled-components": "^3.0.2"
   },
   "dependencies": {
     "css": "^2.2.1"
   },
   "peerDependencies": {
-    "styled-components": "^2.0.0"
+    "styled-components": ">=2.0.0"
   },
   "lint-staged": {
     "*.js": [

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "css": "^2.2.1"
   },
   "peerDependencies": {
-    "styled-components": ">=2.0.0"
+    "styled-components": "^2.0.0 || ^3.0.2"
   },
   "lint-staged": {
     "*.js": [

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,21 +1,43 @@
 const css = require('css')
-const { ServerStyleSheet } = require('styled-components')
-const StyleSheet = require('styled-components/lib/models/StyleSheet')
+const { ServerStyleSheet, isStyledComponent } = require('styled-components')
 
-const isOverV2 = () => Boolean(ServerStyleSheet)
+const isOverV3 = !!isStyledComponent
+const isOverV2 = () => !!ServerStyleSheet
+
+let StyleSheet
+
+/* eslint-disable */
+if (isOverV3) {
+  const secretInternals = require('styled-components')
+    .__DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS
+
+  if (
+    secretInternals === undefined ||
+    secretInternals.StyleSheet === undefined
+  ) {
+    throw new Error(
+      'Could neither find styled-components secret internals nor styled-components/lib/models/StyleSheet.js'
+    )
+  } else {
+    StyleSheet = secretInternals.StyleSheet
+  }
+} else {
+  StyleSheet = require('styled-components/lib/models/StyleSheet').default
+}
+/* eslint-enable */
 
 const isServer = () => typeof document === 'undefined'
 
 const resetStyleSheet = () => {
   if (isOverV2()) {
-    StyleSheet.default.reset(isServer())
+    StyleSheet.reset(isServer())
   }
 }
 
 const getHTML = () =>
   isServer()
     ? new ServerStyleSheet().getStyleTags()
-    : StyleSheet.default.instance.toHTML()
+    : StyleSheet.instance.toHTML()
 
 const extract = regex => {
   let style = ''

--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -540,7 +540,7 @@ html.test .c0 {
   display: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     background: tomato;
   }
@@ -579,7 +579,7 @@ html.test .c0 {
   display: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     background: tomato;
   }
@@ -616,7 +616,7 @@ html.test .c0 {
   display: none;
 }
 
-@media (max-width: 600px) {
+@media (max-width:600px) {
   .c0 {
     background: tomato;
   }

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -155,17 +155,11 @@ test('at rules', () => {
     @media (max-width: 640px) {
       color: green;
     }
-    @supports (display: flexbox) {
-      color: blue;
-    }
   `
 
   toHaveStyleRule(<Wrapper />, 'color', 'red')
   toHaveStyleRule(<Wrapper />, 'color', 'green', {
-    media: '(max-width: 640px)',
-  })
-  toHaveStyleRule(<Wrapper />, 'color', 'blue', {
-    supports: '(display: flexbox)',
+    media: '(max-width:640px)',
   })
 })
 
@@ -205,22 +199,13 @@ test('option combinations', () => {
         color: blue;
       }
     }
-    @supports (display: flexbox) {
-      &[href*='somelink.com'] {
-        color: green;
-      }
-    }
   `
 
   toHaveStyleRule(<Link />, 'color', 'black', {
     modifier: ':hover',
   })
   toHaveStyleRule(<Link />, 'color', 'blue', {
-    media: '(max-width: 640px)',
+    media: '(max-width:640px)',
     modifier: ':hover',
-  })
-  toHaveStyleRule(<Link />, 'color', 'green', {
-    supports: '(display: flexbox)',
-    modifier: "[href*='somelink.com']",
   })
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,22 +1,26 @@
 const { getHashes } = require('../src/utils')
 
-jest.mock('styled-components/lib/models/StyleSheet', () => ({
-  default: {
-    instance: {
-      toHTML() {
-        return `
-          <style data-styled-components="a">
-            /* sc-component-id: sc-1 */
-            .sc-1 {}
-            .a { color: red; }
-          </style>
-          <style data-styled-components="b c">
-            /* sc-component-id: sc-2 */
-            .sc-2 {}
-            .b { color: green; }
-            .c { color: blue; }
-          </style>
-        `
+jest.mock('styled-components', () => ({
+  ServerStyleSheet: true,
+  isStyledComponent: true,
+  __DO_NOT_USE_OR_YOU_WILL_BE_HAUNTED_BY_SPOOKY_GHOSTS: {
+    StyleSheet: {
+      instance: {
+        toHTML() {
+          return `
+            <style data-styled-components="a">
+              /* sc-component-id: sc-1 */
+              .sc-1 {}
+              .a { color: red; }
+            </style>
+            <style data-styled-components="b c">
+              /* sc-component-id: sc-2 */
+              .sc-2 {}
+              .b { color: green; }
+              .c { color: blue; }
+            </style>
+          `
+        },
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2930,7 +2930,7 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-function@^1.0.1, is-function@~1.0.0:
+is-function@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
@@ -5434,23 +5434,22 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-components@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-2.2.1.tgz#f4835f1001c37bcc301ac3865b5d93466de4dd5b"
+styled-components@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.0.2.tgz#dbcd66ee84d444ee4332a7f74027e8a675191593"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
     fbjs "^0.8.9"
     hoist-non-react-statics "^1.2.0"
-    is-function "^1.0.1"
     is-plain-object "^2.0.1"
     prop-types "^15.5.4"
-    stylis "^3.2.1"
+    stylis "^3.4.0"
     supports-color "^3.2.3"
 
-stylis@^3.2.1:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.3.tgz#fed751d792af3f48a247769f55aca05c1a100a09"
+stylis@^3.4.0:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.8.tgz#94380babbcd4c75726215794ca985b38ec96d1a3"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fix #112

This uses the new secret internals that were added in styled-components@3.0.2, since the new v3 versions now use flat bundles and don't expose the `lib/` folder at all.

@MicheleBertoli There are some failing tests which I'm not sure about. Didn't know how to fix them but I think they might be related to an upgrade of stylis?