### PR TITLE
Add better support for various modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,31 @@ test('it works', () => {
 })
 ```
 
+If a rule is nested within another styled-component, the modifier option can be used with the [`css`](https://www.styled-components.com/docs/api#css) helper to target the nested rule.
+
+```js
+const Button = styled.button`
+  color: red;
+`
+
+const ButtonList = styled.div`
+  display: flex;
+
+  ${Button} {
+    flex: 1 0 auto;
+  }
+`
+
+import { css } from 'styled-components';
+
+test('nested buttons are flexed', () => {
+  const tree = renderer.create(<ButtonList><Button /></ButtonList>).toJSON()
+  expect(tree).toHaveStyleRule('flex', '1 0 auto', {
+    modifier: css`${Button}`,
+  })
+})
+```
+
 This matcher works with trees serialized with `react-test-renderer` and shallow renderered or mounted with Enzyme.
 It checks the style rules applied to the root component it receives, therefore to make assertions on components further in the tree they must be provided separately (Enzyme's [find](http://airbnb.io/enzyme/docs/api/ShallowWrapper/find.html) might help).
 

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -1,5 +1,4 @@
 const { getCSS } = require('./utils')
-const { isStyledComponent } = require('styled-components')
 
 const shouldDive = node =>
   typeof node.dive === 'function' && typeof node.type() !== 'string'
@@ -88,20 +87,13 @@ const getDeclaration = (rule, property) =>
 const getDeclarations = (rules, property) =>
   rules.map(rule => getDeclaration(rule, property)).filter(Boolean)
 
-const normalizeModifierOption = (modifiers = []) =>
-  modifiers
-    .map(
-      modifier =>
-        isStyledComponent(modifier)
-          ? `.${modifier.styledComponentId}`
-          : modifier
-    )
-    .join('')
+const normalizeModifierOption = modifier =>
+  Array.isArray(modifier) ? modifier.join('') : modifier
 
 function toHaveStyleRule(received, property, value, options = {}) {
   const classNames = getClassNames(received)
   const ast = getCSS()
-  options.modifier = normalizeModifierOption([].concat(options.modifier))
+  options.modifier = normalizeModifierOption(options.modifier)
   const rules = getRules(ast, classNames, options)
 
   if (!rules.length) {

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -39,11 +39,25 @@ const getAtRules = (ast, options) =>
     )
     .reduce((acc, rules) => acc.concat(rules), [])
 
+const getModifiedClassName = (className, modifier = '') => {
+  const classNameSelector = `.${className}`
+  let prefix = ''
+  modifier = modifier.trim()
+  if (modifier.includes('&')) {
+    modifier = modifier.replace('&', classNameSelector)
+  } else {
+    prefix += classNameSelector
+  }
+  const first = modifier[0]
+  if (first !== ':' && first !== '[') {
+    prefix += ' '
+  }
+  return `${prefix}${modifier}`.trim()
+}
+
 const hasClassNames = (classNames, selectors, options) =>
   classNames.some(className =>
-    selectors.includes(
-      `.${className}${options.modifier ? `${options.modifier}` : ''}`
-    )
+    selectors.includes(getModifiedClassName(className, options.modifier))
   )
 
 const getRules = (ast, classNames, options) => {

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -1,4 +1,5 @@
 const { getCSS } = require('./utils')
+const { isStyledComponent } = require('styled-components')
 
 const shouldDive = node =>
   typeof node.dive === 'function' && typeof node.type() !== 'string'
@@ -87,9 +88,20 @@ const getDeclaration = (rule, property) =>
 const getDeclarations = (rules, property) =>
   rules.map(rule => getDeclaration(rule, property)).filter(Boolean)
 
+const normalizeModifierOption = (modifiers = []) =>
+  modifiers
+    .map(
+      modifier =>
+        isStyledComponent(modifier)
+          ? `.${modifier.styledComponentId}`
+          : modifier
+    )
+    .join('')
+
 function toHaveStyleRule(received, property, value, options = {}) {
   const classNames = getClassNames(received)
   const ast = getCSS()
+  options.modifier = normalizeModifierOption([].concat(options.modifier))
   const rules = getRules(ast, classNames, options)
 
   if (!rules.length) {

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -257,3 +257,58 @@ test('selector modifiers', () => {
     modifier: '.parent &',
   })
 })
+
+test('component modifiers', () => {
+  const Text = styled.span`
+    color: grey;
+  `
+
+  const Link = styled.a`
+    color: white;
+
+    ${Text} {
+      color: blue;
+    }
+
+    > ${Text} span {
+      color: green;
+    }
+
+    ${Text} & {
+      color: purple;
+    }
+  `
+
+  toHaveStyleRule(<Link />, 'color', 'white')
+  toHaveStyleRule(<Text />, 'color', 'grey')
+  toHaveStyleRule(
+    <Link>
+      <Text />
+    </Link>,
+    'color',
+    'blue',
+    {
+      modifier: Text,
+    }
+  )
+  toHaveStyleRule(
+    <Link>
+      <Text />
+    </Link>,
+    'color',
+    'green',
+    {
+      modifier: ['> ', Text, ' span'],
+    }
+  )
+  toHaveStyleRule(
+    <Link>
+      <Text />
+    </Link>,
+    'color',
+    'purple',
+    {
+      modifier: [Text, ' &'],
+    }
+  )
+})

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -166,6 +166,7 @@ test('at rules', () => {
 test('selector modifiers', () => {
   const Link = styled.a`
     color: white;
+
     &:hover {
       color: blue;
     }
@@ -174,6 +175,41 @@ test('selector modifiers', () => {
     }
     &[href*='somelink.com'] {
       color: green;
+    }
+    > div {
+      color: yellow;
+    }
+    span {
+      color: purple;
+    }
+    .child {
+      color: orange;
+    }
+    &.self {
+      color: black;
+    }
+
+    .one,
+    .two {
+      color: olive;
+    }
+
+    ~ div {
+      &.one,
+      &.two {
+        color: pink;
+      }
+    }
+
+    + div {
+      .one,
+      .two {
+        color: salmon;
+      }
+    }
+
+    .parent & {
+      color: red;
     }
   `
 
@@ -187,25 +223,37 @@ test('selector modifiers', () => {
   toHaveStyleRule(<Link />, 'color', 'green', {
     modifier: "[href*='somelink.com']",
   })
-})
-
-test('option combinations', () => {
-  const Link = styled.a`
-    &:hover {
-      color: black;
-    }
-    @media (max-width: 640px) {
-      &:hover {
-        color: blue;
-      }
-    }
-  `
-
-  toHaveStyleRule(<Link />, 'color', 'black', {
-    modifier: ':hover',
+  toHaveStyleRule(<Link />, 'color', 'yellow', {
+    modifier: '> div',
   })
-  toHaveStyleRule(<Link />, 'color', 'blue', {
-    media: '(max-width:640px)',
-    modifier: ':hover',
+  toHaveStyleRule(<Link />, 'color', 'purple', {
+    modifier: 'span',
+  })
+  toHaveStyleRule(<Link />, 'color', 'purple', {
+    modifier: ' span',
+  })
+  toHaveStyleRule(<Link />, 'color', 'orange', {
+    modifier: '.child',
+  })
+  toHaveStyleRule(<Link />, 'color', 'orange', {
+    modifier: ' .child',
+  })
+  toHaveStyleRule(<Link />, 'color', 'black', {
+    modifier: '&.self',
+  })
+  toHaveStyleRule(<Link />, 'color', 'olive', {
+    modifier: '.one',
+  })
+  toHaveStyleRule(<Link />, 'color', 'olive', {
+    modifier: '.two',
+  })
+  toHaveStyleRule(<Link />, 'color', 'pink', {
+    modifier: '~ div.one',
+  })
+  toHaveStyleRule(<Link />, 'color', 'salmon', {
+    modifier: '+ div .two',
+  })
+  toHaveStyleRule(<Link />, 'color', 'red', {
+    modifier: '.parent &',
   })
 })

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import styled, { ThemeProvider } from 'styled-components'
+import styled, { ThemeProvider, css } from 'styled-components'
 import { shallow, mount } from 'enzyme'
 import '../src'
 
@@ -288,7 +288,8 @@ test('component modifiers', () => {
     'color',
     'blue',
     {
-      modifier: Text,
+      // eslint-disable-next-line prettier/prettier
+      modifier: css`${Text}`,
     }
   )
   toHaveStyleRule(
@@ -298,7 +299,7 @@ test('component modifiers', () => {
     'color',
     'green',
     {
-      modifier: ['> ', Text, ' span'],
+      modifier: css`> ${Text} span`,
     }
   )
   toHaveStyleRule(
@@ -308,7 +309,8 @@ test('component modifiers', () => {
     'color',
     'purple',
     {
-      modifier: [Text, ' &'],
+      // eslint-disable-next-line prettier/prettier
+      modifier: css`${Text} &`,
     }
   )
 })


### PR DESCRIPTION
There are 2 commits in this PR as discussed in this issue https://github.com/styled-components/jest-styled-components/issues/64

1. Updates the existing modifier syntax to remove the need to add a starting space. Also adds support for more complex modifiers
2. Updates the modifier syntax to accept child Styled Components by passing in an array of strings and styled components, interpolating them into a final string modifier.

I'm open to discussion about the 2nd one, since that's a pretty ugly looking array. Im not sure how else to support nested components without requiring testers to know about the `styledComponentId` property. If we're otherwise ok with this modification, I can go ahead and update the docs as well.

An alternative I've been thinking of could be something like:
```js
expect(wrapper.find(Text)).toHaveStyleRule('color', 'purple', {
  context: Link,
  modifier: '> & span',
})
```

I haven't really thought in much detail how deeper nested components can be handled in this way (it might just be available out of the box depending on the implementation)