### PR TITLE
Added full dom rendering example in README for themes with enzyme

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The recommended solution is to pass the theme as a prop:
 const wrapper = shallow(<Button theme={theme} />)
 ```
 
-The following function might also help:
+The following function might also help for shallow rendering:
 
 ```js
 const shallowWithTheme = (tree, theme) => {
@@ -251,6 +251,21 @@ const shallowWithTheme = (tree, theme) => {
 }
 
 const wrapper = shallowWithTheme(<Button />, theme)
+```
+
+and for full DOM rendering:
+
+```js
+const mountWithTheme = (tree, theme) => {
+  const context = shallow(<ThemeProvider theme={theme} />)
+    .instance()
+    .getChildContext()
+
+  return mount(tree, {
+    context,
+    childContextTypes: ThemeProvider.childContextTypes // Needed so child components receive the theme prop
+  })
+}
 ```
 
 ## Preact


### PR DESCRIPTION
Updating README per discussion in https://github.com/styled-components/jest-styled-components/issues/106 to include a full DOM rendering example when using enzyme.

@MicheleBertoli lemme know if I should format this differently. Was considering merging the shallow and deep examples together to make it DRY-er but I figured keeping them separate would make the code clearer. Up for suggestions though! 