### PR TITLE
Compat: adds an additional pass at getting the HTML style tags.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -27,10 +27,24 @@ const isServer = () => typeof document === 'undefined'
 
 const resetStyleSheet = () => StyleSheet.reset(isServer())
 
+const getDocumentHTML = () => {
+  let HTML = StyleSheet.instance.toHTML();
+  if(!HTML) {
+    const styleTags = document.getElementsByTagName('style');
+    const parsedStyles = [];
+    for (let i = 0; i < styleTags.length; i += 1) {
+      parsedStyles.push(styleTags[i].outerHTML);
+    }
+    HTML = parsedStyles.join(' ');
+  }
+
+  return HTML;
+}
+
 const getHTML = () =>
   isServer()
     ? new ServerStyleSheet().getStyleTags()
-    : StyleSheet.instance.toHTML()
+    : getDocumentHTML()
 
 const extract = regex => {
   let style = ''


### PR DESCRIPTION
As discussed in https://github.com/styled-components/jest-styled-components/issues/98, this commit fixes a compatibility issues between jest-styled-component 5 and styled-components 3.2 (and possibly earlier versions).

The problem was that the HTML style tags (in some cases) could not be retrieved using the internal styled-components utils (StyleSheet). This commit adds additional code which attempts to do so using the standard `document` API in case the standard method fails.