### PR TITLE
Adding support for Jest asymmetric matchers and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,16 +306,34 @@ test('it works', () => {
 # toHaveStyleRule
 
 The `toHaveStyleRule` matcher is useful to test if a given rule is applied to a component.
-The first argument is the expected property, the second is the expected value (string or RegExp).
+The first argument is the expected property, the second is the expected value which can be a String, RegExp, Jest asymmetric matcher or `undefined`.
 
 ```js
-test('it works', () => {
+const Button = styled.button`
+  color: red;
+  border: 0.05em solid ${props => props.transparent ? 'transparent' : 'black'};
+  cursor: ${props => !props.disabled && 'pointer'};
+  opacity: ${props => props.disabled && '.65'};
+`
+
+test('it applies default styles', () => {
   const tree = renderer.create(<Button />).toJSON()
   expect(tree).toHaveStyleRule('color', 'red')
+  expect(tree).toHaveStyleRule('border', '0.05em solid black')
+  expect(tree).toHaveStyleRule('cursor', 'pointer')
+  expect(tree).toHaveStyleRule('opacity', undefined) // equivalent of the following
+  expect(tree).not.toHaveStyleRule('opacity', expect.any(String))
+})
+
+test('it applies styles according to passed props', () => {
+  const tree = renderer.create(<Button disabled transparent />).toJSON()
+  expect(tree).toHaveStyleRule('border', expect.stringContaining('transparent'))
+  expect(tree).toHaveStyleRule('cursor', undefined)
+  expect(tree).toHaveStyleRule('opacity', '.65')
 })
 ```
 
-The matcher supports a third `options` parameter which makes it possible to search for rules nested within an [At-rule](https://developer.mozilla.org/en/docs/Web/CSS/At-rule) ([media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media)) or to add modifiers to the class selector. This feature is supported in React only, and more options are coming soon.
+The matcher supports an optional third `options` parameter which makes it possible to search for rules nested within an [At-rule](https://developer.mozilla.org/en/docs/Web/CSS/At-rule) ([media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media)) or to add modifiers to the class selector. This feature is supported in React only, and more options are coming soon.
 
 ```js
 const Button = styled.button`

--- a/src/native/toHaveStyleRule.js
+++ b/src/native/toHaveStyleRule.js
@@ -1,10 +1,12 @@
-function toHaveStyleRule(component, name, expected) {
+const { matcherTest, buildReturnMessage } = require('../utils')
+
+function toHaveStyleRule(component, property, expected) {
   const styles = component.props.style.filter(x => x)
 
   /**
    * Convert style name to camel case (so we can compare)
    */
-  const camelCasedName = name.replace(/-(\w)/, (_, match) =>
+  const camelCasedProperty = property.replace(/-(\w)/, (_, match) =>
     match.toUpperCase()
   )
 
@@ -13,37 +15,13 @@ function toHaveStyleRule(component, name, expected) {
    * stylename against this object
    */
   const mergedStyles = styles.reduce((acc, item) => ({ ...acc, ...item }), {})
-  const received = mergedStyles[camelCasedName]
-  const pass = received === expected
+  const received = mergedStyles[camelCasedProperty]
+  const pass = matcherTest(received, expected)
 
-  if (!received) {
-    const error = `${name} isn't in the style rules`
-    return {
-      message: () =>
-        `${this.utils.matcherHint('.toHaveStyleRule')}\n\n` +
-        `Expected ${component.type} to have a style rule:\n` +
-        `  ${this.utils.printExpected(`${name}: ${expected}`)}\n` +
-        'Received:\n' +
-        `  ${this.utils.printReceived(error)}`,
-      pass: false,
-    }
+  return {
+    pass,
+    message: buildReturnMessage(this.utils, pass, property, received, expected),
   }
-
-  const diff =
-    '' +
-    `  ${this.utils.printExpected(`${name}: ${expected}`)}\n` +
-    'Received:\n' +
-    `  ${this.utils.printReceived(`${name}: ${received}`)}`
-
-  const message = pass
-    ? () =>
-        `${this.utils.matcherHint('.not.toHaveStyleRule')}\n\n` +
-        `Expected ${component.type} not to contain:\n${diff}`
-    : () =>
-        `${this.utils.matcherHint('.toHaveStyleRule')}\n\n` +
-        `Expected ${component.type} to have a style rule:\n${diff}`
-
-  return { message, pass }
 }
 
 module.exports = toHaveStyleRule

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -1,4 +1,4 @@
-const { getCSS } = require('./utils')
+const { getCSS, matcherTest, buildReturnMessage } = require('./utils')
 
 const shouldDive = node =>
   typeof node.dive === 'function' && typeof node.type() !== 'string'
@@ -76,9 +76,14 @@ const getRules = (ast, classNames, options) => {
   )
 }
 
-const die = (utils, property) => ({
+const handleMissingRules = options => ({
   pass: false,
-  message: () => `Property not found: ${utils.printReceived(property)}`,
+  message: () =>
+    `No style rules found on passed Component${
+      Object.keys(options).length
+        ? ` using options:\n${JSON.stringify(options)}`
+        : ''
+    }`,
 })
 
 const getDeclaration = (rule, property) =>
@@ -92,41 +97,31 @@ const getDeclaration = (rule, property) =>
 const getDeclarations = (rules, property) =>
   rules.map(rule => getDeclaration(rule, property)).filter(Boolean)
 
-const normalizeModifierOption = modifier =>
-  Array.isArray(modifier) ? modifier.join('') : modifier
+/* eslint-disable prettier/prettier */
+const normalizeOptions = ({ modifier, ...options }) =>
+  modifier
+    ? Object.assign(options, {
+      modifier: Array.isArray(modifier) ? modifier.join('') : modifier,
+    })
+    : options
+/* eslint-enable prettier/prettier */
 
-function toHaveStyleRule(received, property, value, options = {}) {
-  const classNames = getClassNames(received)
+function toHaveStyleRule(component, property, expected, options = {}) {
   const ast = getCSS()
-  options.modifier = normalizeModifierOption(options.modifier)
-  const rules = getRules(ast, classNames, options)
+  const classNames = getClassNames(component)
+  const normalizedOptions = normalizeOptions(options)
+  const rules = getRules(ast, classNames, normalizedOptions)
 
-  if (!rules.length) {
-    return die(this.utils, property)
-  }
+  if (!rules.length) return handleMissingRules(normalizedOptions)
 
   const declarations = getDeclarations(rules, property)
-
-  if (!declarations.length) {
-    return die(this.utils, property)
-  }
-
-  const declaration = declarations.pop()
-
-  const pass =
-    value instanceof RegExp
-      ? value.test(declaration.value)
-      : value === declaration.value
-
-  const message = () =>
-    `Expected ${property}${pass ? ' not ' : ' '}to match:\n` +
-    `  ${this.utils.printExpected(value)}\n` +
-    'Received:\n' +
-    `  ${this.utils.printReceived(declaration.value)}`
+  const declaration = declarations.pop() || {}
+  const received = declaration.value
+  const pass = matcherTest(received, expected)
 
   return {
     pass,
-    message,
+    message: buildReturnMessage(this.utils, pass, property, received, expected),
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,8 +58,36 @@ const getHashes = () =>
     .concat(getComponentIDs())
     .filter(Boolean)
 
+const buildReturnMessage = (utils, pass, property, received, expected) => () =>
+  `${utils.printReceived(
+    !received && !pass
+      ? `Property '${property}' not found in style rules`
+      : `Value mismatch for property '${property}'`
+  )}\n\n` +
+  'Expected\n' +
+  `  ${utils.printExpected(`${property}: ${expected}`)}\n` +
+  'Received:\n' +
+  `  ${utils.printReceived(`${property}: ${received}`)}`
+
+const matcherTest = (received, expected) => {
+  try {
+    const matcher =
+      expected === undefined ||
+      expected.$$typeof === Symbol.for('jest.asymmetricMatcher')
+        ? expected
+        : expect.stringMatching(expected)
+
+    expect(received).toEqual(matcher)
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
 module.exports = {
   resetStyleSheet,
   getCSS,
   getHashes,
+  buildReturnMessage,
+  matcherTest,
 }

--- a/test/__snapshots__/toHaveStyleRule.spec.js.snap
+++ b/test/__snapshots__/toHaveStyleRule.spec.js.snap
@@ -1,10 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`message when property not found 1`] = `"Property not found: [31m\\"a\\"[39m"`;
+exports[`message when property not found 1`] = `
+"[31m\\"Property 'background-color' not found in style rules\\"[39m
+
+Expected
+  [32m\\"background-color: black\\"[39m
+Received:
+  [31m\\"background-color: undefined\\"[39m"
+`;
+
+exports[`message when rules not found 1`] = `"No style rules found on passed Component"`;
+
+exports[`message when rules not found using options 1`] = `
+"No style rules found on passed Component using options:
+{\\"media\\":\\"(max-width:640px)\\",\\"modifier\\":\\":hover\\"}"
+`;
 
 exports[`message when value does not match 1`] = `
-"Expected background to match:
-  [32m\\"red\\"[39m
+"[31m\\"Value mismatch for property 'background'\\"[39m
+
+Expected
+  [32m\\"background: red\\"[39m
 Received:
-  [31m\\"orange\\"[39m"
+  [31m\\"background: orange\\"[39m"
 `;

--- a/test/native/__snapshots__/toHaveStyleRule.spec.js.snap
+++ b/test/native/__snapshots__/toHaveStyleRule.spec.js.snap
@@ -1,10 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`message when value does not match 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toHaveStyleRule([22m[32mexpected[39m[2m)[22m
+exports[`message when property not found 1`] = `
+"[31m\\"Property 'color' not found in style rules\\"[39m
 
-Expected View to have a style rule:
-  [32m\\"background: red\\"[39m
+Expected
+  [32m\\"color: black\\"[39m
 Received:
-  [31m\\"background isn't in the style rules\\"[39m"
+  [31m\\"color: undefined\\"[39m"
+`;
+
+exports[`message when value does not match 1`] = `
+"[31m\\"Value mismatch for property 'background-color'\\"[39m
+
+Expected
+  [32m\\"background-color: red\\"[39m
+Received:
+  [31m\\"background-color: orange\\"[39m"
 `;

--- a/test/native/toHaveStyleRule.spec.js
+++ b/test/native/toHaveStyleRule.spec.js
@@ -13,48 +13,100 @@ test('basic', () => {
   expect(tree).toHaveStyleRule('background-color', 'papayawhip')
 })
 
-xtest('message when property not found', () => {
-  expect(() => expect(null).toHaveStyleRule('a')).toThrowErrorMatchingSnapshot()
-})
+test('message when property not found', () => {
+  const Button = styled.Text`
+    background-color: papayawhip;
+  `
 
-xtest('null', () => {
-  expect(null).not.toHaveStyleRule('a', 'b')
+  expect(() =>
+    expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+      'color',
+      'black'
+    )
+  ).toThrowErrorMatchingSnapshot()
 })
 
 test('message when value does not match', () => {
   const StyledView = styled.View`
-    background: orange;
+    background-color: orange;
   `
 
   expect(() => {
     expect(renderer.create(<StyledView />).toJSON()).toHaveStyleRule(
-      'background',
+      'background-color',
       'red'
     )
   }).toThrowErrorMatchingSnapshot()
 })
 
-xtest('basic', () => {
+test('basic', () => {
   const StyledView = styled.View`
     padding: 4px;
-    background: papayawhip;
+    background-color: papayawhip;
   `
 
   expect(renderer.create(<StyledView />).toJSON()).toHaveStyleRule(
-    'background',
+    'background-color',
     'papayawhip'
   )
 })
 
-xtest('regex', () => {
+test('regex', () => {
   const StyledView = styled.View`
     padding: 4px;
-    background: papayawhip;
+    background-color: papayawhip;
   `
 
   expect(renderer.create(<StyledView />).toJSON()).toHaveStyleRule(
-    'background',
-    /^p/
+    'background-color',
+    /^papaya/
+  )
+})
+
+test('undefined', () => {
+  const Button = styled.Text`
+    ${({ transparent }) => !transparent && 'background-color: papayawhip;'};
+  `
+
+  expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+    'background-color',
+    'papayawhip'
+  )
+  expect(renderer.create(<Button transparent />).toJSON()).toHaveStyleRule(
+    'background-color',
+    undefined
+  )
+})
+
+test('jest asymmetric matchers', () => {
+  const Button = styled.Text`
+    background-color: ${({ transparent }) =>
+      transparent ? 'transparent' : 'papayawhip'};
+  `
+
+  expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+    'background-color',
+    expect.any(String)
+  )
+  expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+    'background-color',
+    expect.stringMatching('papayawhip')
+  )
+  expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+    'background-color',
+    expect.stringMatching(/^papaya/)
+  )
+  expect(renderer.create(<Button transparent />).toJSON()).toHaveStyleRule(
+    'background-color',
+    expect.stringContaining('transparent')
+  )
+  expect(renderer.create(<Button transparent />).toJSON()).not.toHaveStyleRule(
+    'color',
+    expect.any(String)
+  )
+  expect(renderer.create(<Button transparent />).toJSON()).not.toHaveStyleRule(
+    'color',
+    expect.anything()
   )
 })
 

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -23,16 +23,49 @@ const toHaveStyleRule = (component, property, value, options) => {
   expect(mount(component)).toHaveStyleRule(property, value, options)
 }
 
-test('message when property not found', () => {
-  expect(() => expect(null).toHaveStyleRule('a')).toThrowErrorMatchingSnapshot()
-})
-
 test('null', () => {
   expect(null).not.toHaveStyleRule('a', 'b')
 })
 
 test('non-styled', () => {
   notToHaveStyleRule(<div />, 'a', 'b')
+})
+
+test('message when rules not found', () => {
+  expect(() =>
+    expect(renderer.create(<div />).toJSON()).toHaveStyleRule('color', 'black')
+  ).toThrowErrorMatchingSnapshot()
+})
+
+test('message when rules not found using options', () => {
+  const Button = styled.button`
+    color: red;
+  `
+
+  toHaveStyleRule(<Button />, 'color', 'red')
+  expect(() =>
+    expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+      'color',
+      'red',
+      {
+        media: '(max-width:640px)',
+        modifier: ':hover',
+      }
+    )
+  ).toThrowErrorMatchingSnapshot()
+})
+
+test('message when property not found', () => {
+  const Button = styled.button`
+    color: red;
+  `
+
+  expect(() =>
+    expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+      'background-color',
+      'black'
+    )
+  ).toThrowErrorMatchingSnapshot()
 })
 
 test('message when value does not match', () => {
@@ -64,6 +97,42 @@ test('regex', () => {
   `
 
   toHaveStyleRule(<Wrapper />, 'background', /^p/)
+})
+
+test('undefined', () => {
+  const Button = styled.button`
+    cursor: ${({ disabled }) => !disabled && 'pointer'};
+    opacity: ${({ disabled }) => disabled && '.65'};
+  `
+
+  toHaveStyleRule(<Button />, 'opacity', undefined)
+  toHaveStyleRule(<Button />, 'cursor', 'pointer')
+  toHaveStyleRule(<Button disabled />, 'opacity', '.65')
+  toHaveStyleRule(<Button disabled />, 'cursor', undefined)
+})
+
+test('jest asymmetric matchers', () => {
+  const Button = styled.button`
+    border: 0.1em solid
+      ${({ transparent }) => (transparent ? 'transparent' : 'black')};
+  `
+
+  toHaveStyleRule(<Button />, 'border', expect.any(String))
+  toHaveStyleRule(<Button />, 'border', expect.stringMatching('solid'))
+  toHaveStyleRule(<Button />, 'border', expect.stringMatching(/^0.1em/))
+  toHaveStyleRule(<Button />, 'border', expect.stringContaining('black'))
+  notToHaveStyleRule(
+    <Button transparent />,
+    'border',
+    expect.stringContaining('black')
+  )
+  toHaveStyleRule(
+    <Button transparent />,
+    'border',
+    expect.stringContaining('transparent')
+  )
+  notToHaveStyleRule(<Button />, 'color', expect.any(String))
+  notToHaveStyleRule(<Button />, 'color', expect.anything())
 })
 
 test('any component', () => {


### PR DESCRIPTION
This PR aims to address features requested in #146 

### Changelog:
1. Added support to match against Jest asymmetric matchers
2. Added support to match against `undefined` rules
3. Added support for RegEx matching to React Native
4. Shared matching function across React and React Native
5. Introduced a "no style rules" found message that prints options object when received (React)
6. Introduced consistent "property not found" and "property mismatch" messages across React and React Native
7. Fixed all React Native skipped tests plus broken "message when value does not match" test

> Tests for both React and React Native have been added to cover the new functionalities introduced.

#### Notes about the changes introduced:
1. Jest asymmetric matchers are powerful and useful when testing conditional styling based on props.
A rule like this `border: 0.05em solid ${({transparent}) => transparent ? 'transparent' : 'black'}; ` can now be tested in isolation when passing the `transparent` prop like so `expect(<Component transparent />).toHaveStyleRule('border', expect.stringContaining('transparent'))` without testing the entire rule (which consist of border-width, border-style and border-color) nor the need to use a RegEx but rather taking advantage of known solutions provided by Jest matchers.
2. Testing `undefined` is also useful when checking conditional styling based on props. For example this rule `opacity: ${({ disabled }) => disabled && '.65'};` can now be tested like this `expect(<Component />).toHaveStyleRule('opacity', undefined)` when `disabled` prop is not passed; when passing the prop this can be simply tested with `expect(<Component disabled />).toHaveStyleRule('opacity', '.65)`.
This sort of test was not possible before, something similar could have only be achieved with this code `expect(<Component disabled />).not.toHaveStyleRule('opacity', '.65)` which is error prone because it relies on a specific value for the rule, if a developer updates the value by mistake this "negative" assertion would always pass regardless of the presence of the conditional prop (in this case `disabled`).
Thanks to the implementation of the above change `#1` testing for an undefined rule can now also be achieved with Jest asymmetric matchers like so `expect(component).not.toHaveStyleRule('opacity', expect.anything())` however this requires, again, a negative assertion and is definitely less intuitive and more articulated.
3. React Native was validating the `received` vs. `expected` value only with a strict equality comparison (`===`) allowing, therefore, only a string comparison.
Now since a new shared matching function has been introduced for both React and React Native (as per change `#4`) this will also support matching against a RegEx (e.g. `/^exp/`)
4. Matching in React Native was performed with `received === expected` whilst React also had in addition `expected.test(received)` to support RegEx.
These matching functions have been replaced with Jest matchers to remove custom implementation and to allow support for Jest asymmetric matchers and `undefined` as detailed in notes for changes `#1` and `#2`. The above to rules present in the React implementation are simply replaced by Jest's `expect.stringMatching(expected)` which has built in support for both Strings and RegEx values.
5. When an empty set of rules was retrieved a "property not found" message was returned to the user. This has now been replaced with a dedicated "no rules found" message to provide additional clue that the problem is not with a specific property but with the entire styles supposedly applied to the component.
In addition to that this message will print the third argument, `options`, (when passed) to help the user identify possible issues with missing rules given a specific modifier or media applied.
6. A new function, `buildReturnMessage`, is defined in the utils to provide a message for "property not found" and "property mismatch" which are the two messages required by both React and React Native; to allow consistent messaging across the two implementations.
7. A number of tests in React Native were skipped using `xtest`. The main issue with these tests is that  they were checking on properties such as `background` but React Native rules are identified individually. For example when applying a rule like `border: 1px solid black` this is translated into the following three different rules `border-width: 1px`, `border-style: solid`, `border-color: black`; hence these rules must be tested individually.
The "null" test in React Native (which was also skipped) has been removed because is not relevant since in React Native the passed component is an object with an expected `props` object property; hence passing `null` instead of an object component is not relevant.
Similarly the "message when property not found" test has been fixed replacing the passed `null` with a valid styled React Native component.
Finally the "message when value does not match" test has been fixed since the wrong assertion caused the snapshot to be based on the wrong message `background isn't in the style rules` instead of `Expected: background-color: red    Received: background-color: orange`