### PR TITLE
Styles are added to the snapshot as valid HTML in the <style> element.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ When we rerun the test, the output is different: the style rules are included in
 - Snapshot
 + Received
 
++<style>
 +.c0 {
 +  color: green;
 +}
++</style>
 +
  <button
 -  className="sc-bdVaJa rOCEJ"
@@ -134,9 +136,11 @@ This is the resulting snapshot:
 
 ```js
 exports[`it works 1`] = `
+<style>
 .c0 {
   color: green;
 }
+</style>
 
 <button
   className="c0"
@@ -162,6 +166,7 @@ Thanks to Jest Styled Components, Jest is now able to provide the exact informat
 -  color: green;
 +  color: blue;
  }
+ </style>
 
  <button
    className="c0"

--- a/src/styleSheetSerializer.js
+++ b/src/styleSheetSerializer.js
@@ -104,7 +104,7 @@ const styleSheetSerializer = {
     const style = getStyle(classNames)
     const code = print(val)
 
-    let result = `${style}${style ? '\n\n' : ''}${code}`
+    let result = style? `<style>\n${style}\n</style>\n\n${code}`: code
     result = replaceClassNames(result, classNames, style)
     result = replaceHashes(result, hashes)
 

--- a/src/styleSheetSerializer.js
+++ b/src/styleSheetSerializer.js
@@ -15,7 +15,10 @@ const getNodes = (node, nodes = []) => {
   return nodes
 }
 
-const markNodes = nodes => nodes.forEach(node => (node[KEY] = true))
+const markNodes = nodes =>
+  nodes.forEach(node => {
+    node[KEY] = true
+  })
 
 const getClassNames = nodes =>
   nodes.reduce((classNames, node) => {
@@ -104,7 +107,7 @@ const styleSheetSerializer = {
     const style = getStyle(classNames)
     const code = print(val)
 
-    let result = style? `<style>\n${style}\n</style>\n\n${code}`: code
+    let result = style ? `<style>\n${style}\n</style>\n\n${code}` : code
     result = replaceClassNames(result, classNames, style)
     result = replaceHashes(result, hashes)
 

--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`any component: mount 1`] = `
+<style>
 .c0 {
   color: palevioletred;
   font-weight: bold;
 }
+</style>
 
 <div>
   <Link>
@@ -28,10 +30,12 @@ exports[`any component: mount 1`] = `
 `;
 
 exports[`any component: react-test-renderer 1`] = `
+<style>
 .c0 {
   color: palevioletred;
   font-weight: bold;
 }
+</style>
 
 <div>
   <a
@@ -61,9 +65,11 @@ exports[`any component: shallow 1`] = `
 `;
 
 exports[`attaching additional props: mount 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <styled.div>
   <div
@@ -73,9 +79,11 @@ exports[`attaching additional props: mount 1`] = `
 `;
 
 exports[`attaching additional props: react-test-renderer 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <div
   className="div c0"
@@ -83,9 +91,11 @@ exports[`attaching additional props: react-test-renderer 1`] = `
 `;
 
 exports[`attaching additional props: shallow 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <div
   className="div c0"
@@ -93,6 +103,7 @@ exports[`attaching additional props: shallow 1`] = `
 `;
 
 exports[`basic: mount 1`] = `
+<style>
 .c0 {
   padding: 4em;
   background: papayawhip;
@@ -103,6 +114,7 @@ exports[`basic: mount 1`] = `
   text-align: center;
   color: palevioletred;
 }
+</style>
 
 <styled.section>
   <section
@@ -120,6 +132,7 @@ exports[`basic: mount 1`] = `
 `;
 
 exports[`basic: react-test-renderer 1`] = `
+<style>
 .c0 {
   padding: 4em;
   background: papayawhip;
@@ -130,6 +143,7 @@ exports[`basic: react-test-renderer 1`] = `
   text-align: center;
   color: palevioletred;
 }
+</style>
 
 <section
   className="c0"
@@ -143,10 +157,12 @@ exports[`basic: react-test-renderer 1`] = `
 `;
 
 exports[`basic: shallow 1`] = `
+<style>
 .c0 {
   padding: 4em;
   background: papayawhip;
 }
+</style>
 
 <section
   className="c0"
@@ -158,6 +174,7 @@ exports[`basic: shallow 1`] = `
 `;
 
 exports[`duplicated components: mount 1`] = `
+<style>
 .c0 {
   color: red;
 }
@@ -165,6 +182,7 @@ exports[`duplicated components: mount 1`] = `
 .c1 {
   color: green;
 }
+</style>
 
 <div>
   <styled.div>
@@ -188,6 +206,7 @@ exports[`duplicated components: mount 1`] = `
 `;
 
 exports[`duplicated components: react-test-renderer 1`] = `
+<style>
 .c0 {
   color: red;
 }
@@ -195,6 +214,7 @@ exports[`duplicated components: react-test-renderer 1`] = `
 .c1 {
   color: green;
 }
+</style>
 
 <div>
   <div
@@ -242,6 +262,7 @@ exports[`empty style: shallow 1`] = `
 `;
 
 exports[`extending styles: mount 1`] = `
+<style>
 .c0 {
   color: palevioletred;
   font-size: 1em;
@@ -261,6 +282,7 @@ exports[`extending styles: mount 1`] = `
   color: tomato;
   border-color: tomato;
 }
+</style>
 
 <div>
   <styled.button>
@@ -281,6 +303,7 @@ exports[`extending styles: mount 1`] = `
 `;
 
 exports[`extending styles: react-test-renderer 1`] = `
+<style>
 .c0 {
   color: palevioletred;
   font-size: 1em;
@@ -300,6 +323,7 @@ exports[`extending styles: react-test-renderer 1`] = `
   color: tomato;
   border-color: tomato;
 }
+</style>
 
 <div>
   <button
@@ -327,9 +351,11 @@ exports[`extending styles: shallow 1`] = `
 `;
 
 exports[`included class name: mount 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <styled.div>
   <div
@@ -339,9 +365,11 @@ exports[`included class name: mount 1`] = `
 `;
 
 exports[`included class name: react-test-renderer 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <div
   className="i c0"
@@ -349,9 +377,11 @@ exports[`included class name: react-test-renderer 1`] = `
 `;
 
 exports[`included class name: shallow 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <div
   className="i c0"
@@ -387,6 +417,7 @@ exports[`non-styled: shallow 1`] = `<div />`;
 exports[`null 1`] = `null`;
 
 exports[`referring to other components: mount 1`] = `
+<style>
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -428,6 +459,7 @@ exports[`referring to other components: mount 1`] = `
   content: '◀';
   margin: 0 10px;
 }
+</style>
 
 <styled.a
   href="#"
@@ -453,6 +485,7 @@ exports[`referring to other components: mount 1`] = `
 `;
 
 exports[`referring to other components: react-test-renderer 1`] = `
+<style>
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -494,6 +527,7 @@ exports[`referring to other components: react-test-renderer 1`] = `
   content: '◀';
   margin: 0 10px;
 }
+</style>
 
 <a
   className="c0 c1"
@@ -511,9 +545,11 @@ exports[`referring to other components: react-test-renderer 1`] = `
 `;
 
 exports[`shallow with theme 1`] = `
+<style>
 .c0 {
   color: mediumseagreen;
 }
+</style>
 
 <button
   className="c0"
@@ -523,6 +559,7 @@ exports[`shallow with theme 1`] = `
 `;
 
 exports[`supported css: mount 1`] = `
+<style>
 .c0 {
   padding: 2em 1em;
   background: papayawhip;
@@ -550,6 +587,7 @@ html.test .c0 {
     background: yellow;
   }
 }
+</style>
 
 <styled.div>
   <div
@@ -563,6 +601,7 @@ html.test .c0 {
 `;
 
 exports[`supported css: react-test-renderer 1`] = `
+<style>
 .c0 {
   padding: 2em 1em;
   background: papayawhip;
@@ -590,6 +629,7 @@ html.test .c0 {
     background: yellow;
   }
 }
+</style>
 
 <div
   className="c0"
@@ -601,6 +641,7 @@ html.test .c0 {
 `;
 
 exports[`supported css: shallow 1`] = `
+<style>
 .c0 {
   padding: 2em 1em;
   background: papayawhip;
@@ -628,6 +669,7 @@ html.test .c0 {
     background: yellow;
   }
 }
+</style>
 
 <div
   className="c0"
@@ -639,6 +681,7 @@ html.test .c0 {
 `;
 
 exports[`theming: mount 1`] = `
+<style>
 .c0 {
   font-size: 1em;
   margin: 1em;
@@ -656,6 +699,7 @@ exports[`theming: mount 1`] = `
   color: mediumseagreen;
   border: 2px solid mediumseagreen;
 }
+</style>
 
 <div>
   <styled.button
@@ -696,6 +740,7 @@ exports[`theming: mount 1`] = `
 `;
 
 exports[`theming: react-test-renderer 1`] = `
+<style>
 .c0 {
   font-size: 1em;
   margin: 1em;
@@ -713,6 +758,7 @@ exports[`theming: react-test-renderer 1`] = `
   color: mediumseagreen;
   border: 2px solid mediumseagreen;
 }
+</style>
 
 <div>
   <button
@@ -760,9 +806,11 @@ exports[`theming: shallow 1`] = `
 `;
 
 exports[`trailing white spaces: mount 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <styled.div>
   <div
@@ -772,9 +820,11 @@ exports[`trailing white spaces: mount 1`] = `
 `;
 
 exports[`trailing white spaces: react-test-renderer 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <div
   className="div   c0"
@@ -782,9 +832,11 @@ exports[`trailing white spaces: react-test-renderer 1`] = `
 `;
 
 exports[`trailing white spaces: shallow 1`] = `
+<style>
 .c0 {
   color: red;
 }
+</style>
 
 <div
   className="div   c0"

--- a/test/preact/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/preact/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -1,6 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`basic 1`] = `
+<style>
 .c0 {
   padding: 4em;
   background: papayawhip;
@@ -11,6 +12,7 @@ exports[`basic 1`] = `
   text-align: center;
   color: palevioletred;
 }
+</style>
 
 <section
   class="c0"


### PR DESCRIPTION
**Note this is a breaking change.**

This change implements the enhancement issue "Please consider wrapping the added style string in <style> element #135". 

**Problem**:  The styles added to the snapshot by _jest-styled-components_ are not added as valid HTML. Therefore _jest-html_ can not render the HTML with the added styles. 

**Solution**: Then the styles are added to the snapshot, add then in a `<style>` element. 

It would have been nice to be able to implement this change in a backward compatible way, where the feature is enabled by an configuration object injected when the module is imported. However, due to the unusual way the _serializer_ is added this does not seem possible.

Since this is a breaking change any existing tests must be successfully tested with a previous version before updating _jest-styled-components_. Then the snapshots must be updated with `jest -u`.