### PR TITLE
Use Prettier as single source of truth for formatting rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,8 @@
 {
-  "extends": "airbnb",
-
-  "plugins": [
-    "prettier"
-  ],
+  "extends": ["airbnb", "plugin:prettier/recommended"],
 
   "env": {
-    "jest": "true"
+    "jest": true
   },
 
   "rules": {
@@ -31,6 +27,6 @@
     }],
     "react/jsx-filename-extension": ["error", { "extensions": [".js"] }],
     "react/prop-types": ["error", { "skipUndeclared": true }],
-    "semi": ["error", "never"],
+    "semi": ["error", "never"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "enzyme-to-json": "^3.3.1",
     "eslint": "^3.17.1",
     "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-prettier": "^2.1.2",

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -97,15 +97,13 @@ const getDeclaration = (rule, property) =>
 const getDeclarations = (rules, property) =>
   rules.map(rule => getDeclaration(rule, property)).filter(Boolean)
 
-/* eslint-disable prettier/prettier */
 const normalizeOptions = ({ modifier, ...options }) =>
   modifier
     ? {
-      ...options,
-      modifier: Array.isArray(modifier) ? modifier.join('') : modifier,
-    }
+        ...options,
+        modifier: Array.isArray(modifier) ? modifier.join('') : modifier,
+      }
     : options
-/* eslint-enable prettier/prettier */
 
 function toHaveStyleRule(component, property, expected, options = {}) {
   const ast = getCSS()


### PR DESCRIPTION
### Introduction
This project is using ESlint as linting utility and Prettier for code formatting.

### The issue
ESlint is an advanced linting tool that also include a number of formatting rules.
The entire reasons behind Prettier is to be opinionated about code formatting.
In some complex cases (e.g. inline ternaries) the two tools will actually conflict with each other as they have different requirements about code formatting.

### The fix
When it comes to code formatting we need a single source of truth to deal consistently with formatting styles; since Prettier job is exactly to care about code formatting its rules must be given precedence.
I have introduced the `eslint-config-prettier` dependency that allows ESLint not to complain about formatting "issues" which are simply a different preference than what Prettier does.

The benefit can already be seen in `toHaveStyleRule.js` as the `/* eslint-disable prettier/prettier */` has been removed; Prettier formatting rule has, in fact, been implemented and ESlint is no longer fighting it.

### Request
I would appreciate if following the merge of this PR you could release a new "next" version that includes this and #155.
As you can see the benefit providing these "next" releases is that I can plug them into my current projects and figure out whether or not additional issues might need to be addressed.