### PR TITLE
Export styleSheetSerializer, toHaveStyleRule

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "./typings/index.d.ts",
   "files": [
     "native",
+    "serializer",
     "src",
     "typings"
   ],

--- a/serializer/index.js
+++ b/serializer/index.js
@@ -1,0 +1,3 @@
+const styleSheetSerializer = require('../src/styleSheetSerializer')
+
+module.exports.styleSheetSerializer = styleSheetSerializer


### PR DESCRIPTION
Hello,

I would like to integrate `jest-styled-components` with `jest-specific-snapshot`. Unfortunately, serializers are added differently in this case. We must use a function `addSerializer` from package `jest-specific-snapshot`, but I can not do it because class `styleSheetSerializer` is private.

Thanks in advance.
