### PR TITLE
Updated peerDependency to account for styled-components v4.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,3 @@
 {
-  "presets": ["es2015", "react"],
-
-  "plugins": [
-    "transform-object-rest-spread",
-    "transform-class-properties"
-  ]
+  "presets": ["env", "react"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-jest": "^23.4.2",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
@@ -58,7 +56,7 @@
     "css": "^2.2.4"
   },
   "peerDependencies": {
-    "styled-components": "^2.0.0 || ^3.0.2"
+    "styled-components": "^2.0.0 || ^3.0.2 || >= 4.x"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Also updated babel config to use `env` preset to avoid warning in the console when using the deprecated `es2015` preset.