### PR TITLE
Proposal for handling properties/css rules with no value

### DIFF
--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -151,7 +151,7 @@ function toHaveStyleRule(component, property, expected, options = {}) {
   }
 
   const declarations = getDeclarations(rules, property)
-  const declaration = declarations.pop() || {}
+  const declaration = declarations.pop() || { value: null }
   const received = declaration.value
   const pass = matcherTest(received, expected)
 

--- a/test/__snapshots__/toHaveStyleRule.spec.js.snap
+++ b/test/__snapshots__/toHaveStyleRule.spec.js.snap
@@ -6,7 +6,7 @@ exports[`message when property not found 1`] = `
 Expected
   [32m\\"background-color: black\\"[39m
 Received:
-  [31m\\"background-color: undefined\\"[39m"
+  [31m\\"background-color: null\\"[39m"
 `;
 
 exports[`message when rules not found 1`] = `"No style rules found on passed Component"`;

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -45,6 +45,7 @@ test('null', () => {
 
 test('non-styled', () => {
   notToHaveStyleRule(<div />, 'a', 'b')
+  notToHaveStyleRule(<div />, 'a')
 })
 
 test('message when rules not found', () => {
@@ -137,16 +138,29 @@ test('complex string', () => {
   toHaveStyleRule(<Wrapper />, 'border', '1px solid rgba(0,0,0,0.125)')
 })
 
-test('undefined', () => {
+test('conditional rule - null value', () => {
   const Button = styled.button`
     cursor: ${({ disabled }) => !disabled && 'pointer'};
     opacity: ${({ disabled }) => disabled && '.65'};
   `
 
-  toHaveStyleRule(<Button />, 'opacity', undefined)
+  toHaveStyleRule(<Button />, 'opacity', null)
   toHaveStyleRule(<Button />, 'cursor', 'pointer')
   toHaveStyleRule(<Button disabled />, 'opacity', '.65')
-  toHaveStyleRule(<Button disabled />, 'cursor', undefined)
+  toHaveStyleRule(<Button disabled />, 'cursor', null)
+})
+
+test('at rules initially no value', () => {
+  const Button = styled.button`
+    @media (max-width: 640px) {
+      width: 50%;
+    }
+  `
+  notToHaveStyleRule(<Button />, 'width')
+  toHaveStyleRule(<Button />, 'width', null)
+  toHaveStyleRule(<Button />, 'width', expect.any(String), {
+    media: '(max-width: 640px)',
+  })
 })
 
 test('jest asymmetric matchers', () => {


### PR DESCRIPTION
Make it possible to use not.toHaveStyleRule when rule defined for higher resolutions.