### PR TITLE
 toHaveStyleRule to work with not passed expected value and negated ".not" modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ test('it works', () => {
 
 The `toHaveStyleRule` matcher is useful to test if a given rule is applied to a component.
 The first argument is the expected property, the second is the expected value which can be a String, RegExp, Jest asymmetric matcher or `undefined`.
+When used with a negated ".not" modifier the second argument is optional and can be omitted.
 
 ```js
 const Button = styled.button`
@@ -362,8 +363,9 @@ test('it applies default styles', () => {
   expect(tree).toHaveStyleRule('color', 'red')
   expect(tree).toHaveStyleRule('border', '0.05em solid black')
   expect(tree).toHaveStyleRule('cursor', 'pointer')
-  expect(tree).toHaveStyleRule('opacity', undefined) // equivalent of the following
+  expect(tree).not.toHaveStyleRule('opacity') // equivalent of the following two
   expect(tree).not.toHaveStyleRule('opacity', expect.any(String))
+  expect(tree).toHaveStyleRule('opacity', undefined)
 })
 
 test('it applies styles according to passed props', () => {

--- a/src/native/toHaveStyleRule.js
+++ b/src/native/toHaveStyleRule.js
@@ -16,7 +16,9 @@ function toHaveStyleRule(component, property, expected) {
    */
   const mergedStyles = styles.reduce((acc, item) => ({ ...acc, ...item }), {})
   const received = mergedStyles[camelCasedProperty]
-  const pass = matcherTest(received, expected)
+  const matches = matcherTest(received, expected)
+  // if expected value is not passed and we have a negated ".not" modifier we need to flip our assertion
+  const pass = !expected && this.isNot ? !matches : matches
 
   return {
     pass,

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -30,7 +30,7 @@ const hasAtRule = options =>
   Object.keys(options).some(option => ['media', 'supports'].includes(option))
 
 const getAtRules = (ast, options) => {
-  const mediaRegex = /(\([a-z-]+:)\s?([a-z0-9]+\))/g
+  const mediaRegex = /(\([a-z-]+:)\s?([a-z0-9.]+\))/g
 
   return Object.keys(options)
     .map(option =>

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -101,13 +101,13 @@ const getDeclaration = (rule, property) =>
 const getDeclarations = (rules, property) =>
   rules.map(rule => getDeclaration(rule, property)).filter(Boolean)
 
-const normalizeOptions = (options) =>
+const normalizeOptions = options =>
   options.modifier
-    ? Object.assign(
-        {},
-        options,
-        { modifier: Array.isArray(options.modifier) ? options.modifier.join('') : options.modifier },
-      )
+    ? Object.assign({}, options, {
+        modifier: Array.isArray(options.modifier)
+          ? options.modifier.join('')
+          : options.modifier,
+      })
     : options
 
 function toHaveStyleRule(component, property, expected, options = {}) {
@@ -123,7 +123,9 @@ function toHaveStyleRule(component, property, expected, options = {}) {
   const declarations = getDeclarations(rules, property)
   const declaration = declarations.pop() || {}
   const received = declaration.value
-  const pass = matcherTest(received, expected)
+  const matches = matcherTest(received, expected)
+  // if expected value is not passed and we have a negated ".not" modifier we need to flip our assertion
+  const pass = !expected && this.isNot ? !matches : matches
 
   return {
     pass,

--- a/test/native/toHaveStyleRule.spec.js
+++ b/test/native/toHaveStyleRule.spec.js
@@ -78,6 +78,20 @@ test('undefined', () => {
   )
 })
 
+test('negated ".not" modifier with no value', () => {
+  const Button = styled.Text`
+    ${({ transparent }) => !transparent && 'background-color: papayawhip;'};
+  `
+
+  expect(renderer.create(<Button />).toJSON()).toHaveStyleRule(
+    'background-color',
+    'papayawhip'
+  )
+  expect(renderer.create(<Button transparent />).toJSON()).not.toHaveStyleRule(
+    'background-color'
+  )
+})
+
 test('jest asymmetric matchers', () => {
   const Button = styled.Text`
     background-color: ${({ transparent }) =>

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -259,6 +259,9 @@ test('at rules', () => {
     @media (min-width: 200px) and (max-width: 640px) {
       color: blue;
     }
+    @media (min-width: 576px) and (max-width: 767.98px) {
+      color: red;
+    }
   `
 
   toHaveStyleRule(<Wrapper />, 'color', 'red')
@@ -279,6 +282,9 @@ test('at rules', () => {
   })
   toHaveStyleRule(<Wrapper />, 'color', 'blue', {
     media: '(min-width:200px) and (max-width: 640px)',
+  })
+  toHaveStyleRule(<Wrapper />, 'color', 'red', {
+    media: '(min-width: 576px) and (max-width: 767.98px)',
   })
 })
 

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -143,6 +143,15 @@ test('undefined', () => {
   toHaveStyleRule(<Button disabled />, 'cursor', undefined)
 })
 
+test('negated ".not" modifier with no value', () => {
+  const Button = styled.button`
+    opacity: ${({ disabled }) => disabled && '.65'};
+  `
+
+  notToHaveStyleRule(<Button />, 'opacity')
+  toHaveStyleRule(<Button disabled />, 'opacity', '.65')
+})
+
 test('jest asymmetric matchers', () => {
   const Button = styled.button`
     border: 0.1em solid


### PR DESCRIPTION
Following the input from #205 I'm creating this PR to add a feature to `toHaveStyleRule` to be able to work with a negated ".not" modifier and a not passed expected value to allow the following syntax:
```
expect(<Component />).not.toHaveStyleRule('opacity')
```

Key-points:
1. No breaking changes
2. Purely additive, doesn't revisit any existing behaviour
3. It supports both React and React-Native
4. Tests for this new use case are added for both web and native
5. The Readme has been updated to document the use of this new feature

I know the work on this project is currently focused around compatibility with SCv4, however this should be merged on existing master and be followed by an new npm release.
This will not only allow existing users to benefit from this feature even before SCv4 work is completed but will also allow users who are not going to update to SCv4 in the near future from having a new feature available.

This PR can then be merged into the v4 branch to reflect the changes introduced.