### PR TITLE
remove comma in object assign function, which broken in unit test

### DIFF
--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -106,7 +106,7 @@ const normalizeOptions = (options) =>
     ? Object.assign(
         {},
         options,
-        { modifier: Array.isArray(options.modifier) ? options.modifier.join('') : options.modifier },
+        { modifier: Array.isArray(options.modifier) ? options.modifier.join('') : options.modifier }
       )
     : options
 


### PR DESCRIPTION
remove comma in object assign function, which broken in unit test 

```
node_modules/jest-styled-components/src/toHaveStyleRule.js:110
          )
          ^
    
    SyntaxError: Unexpected token )
      
      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:305:17)
      at Object.<anonymous> (node_modules/jest-styled-components/src/index.js:1:114)
      at Object.<anonymous> (test/setup.js:4:1)

```

in package.json:

    "jest-styled-components": "^6.2.2",
    "react": "^16.6.1",
    "react-dom": "^16.6.1"
    "jest": "^23.6.0"