### PR TITLE
Fix negated ".not" modifier usage edge case

### DIFF
--- a/src/native/toHaveStyleRule.js
+++ b/src/native/toHaveStyleRule.js
@@ -16,9 +16,10 @@ function toHaveStyleRule(component, property, expected) {
    */
   const mergedStyles = styles.reduce((acc, item) => ({ ...acc, ...item }), {})
   const received = mergedStyles[camelCasedProperty]
-  const matches = matcherTest(received, expected)
-  // if expected value is not passed and we have a negated ".not" modifier we need to flip our assertion
-  const pass = !expected && this.isNot ? !matches : matches
+  const pass =
+    !received && !expected && this.isNot
+      ? false
+      : matcherTest(received, expected)
 
   return {
     pass,

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -123,9 +123,10 @@ function toHaveStyleRule(component, property, expected, options = {}) {
   const declarations = getDeclarations(rules, property)
   const declaration = declarations.pop() || {}
   const received = declaration.value
-  const matches = matcherTest(received, expected)
-  // if expected value is not passed and we have a negated ".not" modifier we need to flip our assertion
-  const pass = !expected && this.isNot ? !matches : matches
+  const pass =
+    !received && !expected && this.isNot
+      ? false
+      : matcherTest(received, expected)
 
   return {
     pass,

--- a/test/native/toHaveStyleRule.spec.js
+++ b/test/native/toHaveStyleRule.spec.js
@@ -90,6 +90,10 @@ test('negated ".not" modifier with no value', () => {
   expect(renderer.create(<Button transparent />).toJSON()).not.toHaveStyleRule(
     'background-color'
   )
+  expect(renderer.create(<Button />).toJSON()).not.toHaveStyleRule(
+    'background-color',
+    undefined
+  )
 })
 
 test('jest asymmetric matchers', () => {

--- a/test/native/toHaveStyleRule.spec.js
+++ b/test/native/toHaveStyleRule.spec.js
@@ -90,8 +90,31 @@ test('negated ".not" modifier with no value', () => {
   expect(renderer.create(<Button transparent />).toJSON()).not.toHaveStyleRule(
     'background-color'
   )
+})
+
+test('negated ".not" modifier with value', () => {
+  const Button = styled.Text`
+    padding: 4px;
+  `
+
   expect(renderer.create(<Button />).toJSON()).not.toHaveStyleRule(
-    'background-color',
+    'padding',
+    '2px'
+  )
+  expect(renderer.create(<Button />).toJSON()).not.toHaveStyleRule(
+    'padding',
+    ''
+  )
+  expect(renderer.create(<Button />).toJSON()).not.toHaveStyleRule(
+    'padding',
+    null
+  )
+  expect(renderer.create(<Button />).toJSON()).not.toHaveStyleRule(
+    'padding',
+    false
+  )
+  expect(renderer.create(<Button />).toJSON()).not.toHaveStyleRule(
+    'padding',
     undefined
   )
 })

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -150,6 +150,7 @@ test('negated ".not" modifier with no value', () => {
 
   notToHaveStyleRule(<Button />, 'opacity')
   toHaveStyleRule(<Button disabled />, 'opacity', '.65')
+  notToHaveStyleRule(<Button disabled />, 'opacity', undefined)
 })
 
 test('jest asymmetric matchers', () => {

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -150,7 +150,18 @@ test('negated ".not" modifier with no value', () => {
 
   notToHaveStyleRule(<Button />, 'opacity')
   toHaveStyleRule(<Button disabled />, 'opacity', '.65')
-  notToHaveStyleRule(<Button disabled />, 'opacity', undefined)
+})
+
+test('negated ".not" modifier with value', () => {
+  const Button = styled.button`
+    opacity: 0.65;
+  `
+
+  notToHaveStyleRule(<Button />, 'opacity', '0.50')
+  notToHaveStyleRule(<Button />, 'opacity', '')
+  notToHaveStyleRule(<Button />, 'opacity', null)
+  notToHaveStyleRule(<Button />, 'opacity', false)
+  notToHaveStyleRule(<Button />, 'opacity', undefined)
 })
 
 test('jest asymmetric matchers', () => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@ interface AsymmetricMatcher {
   sample?: string | RegExp | object | Array<any> | Function;
 }
 
-type Value = string | number | RegExp | AsymmetricMatcher | undefined
+type Value = string | number | RegExp | AsymmetricMatcher | undefined;
 
 interface Options {
   media?: string;
@@ -14,6 +14,6 @@ interface Options {
 declare namespace jest {
 
   interface Matchers<R> {
-    toHaveStyleRule(property: string, value: Value, options?: Options): R;
+    toHaveStyleRule(property: string, value?: Value, options?: Options): R;
   }
 }


### PR DESCRIPTION
Hey @MicheleBertoli,
quick PR to fix a small edge case introduced in #206.

This is to fix a scenario which would cause the following test to fail when it shouldn't
```javascript
  const Button = styled.button`
    opacity: .65;
  `

  expect(<Button />).not.toHaveStyleRule('opacity', undefined)
```

### Info
Since the `opacity` rule is applied to `Button` we can also write a test to check that the rule should not be undefined.
I consider this an edge case since this test is certainly convoluted and possibly pointless as most likely if you have a rule applied you want to write a test to check its value.

### Fix
When the requested rule is undefined and the expected value is not passed or falsy and the negated `.not` modifier is used then we can return directly `false` to make our test pass without any need to use the `matcherTest` util which would always return true, since it evaluates `expect(undefined).toEqual(undefined)`.
If the above conditions don't apply then we leave the matching logic to the `matcherTest` util as before.

This approach avoid the invocation of a function when is not required (as the result is predictable) and also simplifies the logic as it doesn't require flipping of the assertion.

### Notes
- More comprehensive tests have been added on the use of the negated `.not` modifier with and without values.
- As usual the changes are applied to both web and native.
- I took the opportunity of this additional PR to also fix the types, since now as part of #206 the expected value is actually optional.

I actually realised this was probably going to create the issue mentioned above the day after opening #206 but have had a very crazy week and didn't manage to push a fix earlier.
Now that is weekend I finally got 5mins to get this sorted; sorry it will require you to publish v6.3.1 🙏