### PR TITLE
Abstract getStyleRule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const toHaveStyleRule = require('./toHaveStyleRule')
+const { getStyleRule, toHaveStyleRule } = require('./toHaveStyleRule')
 const styleSheetSerializer = require('./styleSheetSerializer')
 const { resetStyleSheet } = require('./utils')
 
@@ -6,3 +6,5 @@ resetStyleSheet()
 
 expect.addSnapshotSerializer(styleSheetSerializer)
 expect.extend({ toHaveStyleRule })
+
+module.exports = { getStyleRule }

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -149,4 +149,4 @@ function toHaveStyleRule(component, property, expected, options = {}) {
   }
 }
 
-module.exports = toHaveStyleRule
+module.exports = { getStyleRule, toHaveStyleRule }

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -80,15 +80,12 @@ const getRules = (ast, classNames, options) => {
   )
 }
 
-const handleMissingRules = options => ({
-  pass: false,
-  message: () =>
-    `No style rules found on passed Component${
-      Object.keys(options).length
-        ? ` using options:\n${JSON.stringify(options)}`
-        : ''
-    }`,
-})
+const handleMissingRules = options =>
+  `No style rules found on passed Component${
+    Object.keys(options).length
+      ? ` using options:\n${JSON.stringify(options)}`
+      : ''
+  }`
 
 const getDeclaration = (rule, property) =>
   rule.declarations
@@ -110,27 +107,45 @@ const normalizeOptions = options =>
       })
     : options
 
-function toHaveStyleRule(component, property, expected, options = {}) {
+function getStyleRule(component, property, options = {}) {
   const classNames = getClassNames(component)
   const ast = getCSS()
   const normalizedOptions = normalizeOptions(options)
   const rules = getRules(ast, classNames, normalizedOptions)
 
   if (!rules.length) {
-    return handleMissingRules(normalizedOptions)
+    throw new Error(handleMissingRules(normalizedOptions))
   }
 
   const declarations = getDeclarations(rules, property)
   const declaration = declarations.pop() || {}
-  const received = declaration.value
-  const pass =
-    !received && !expected && this.isNot
-      ? false
-      : matcherTest(received, expected)
+  return declaration.value
+}
 
-  return {
-    pass,
-    message: buildReturnMessage(this.utils, pass, property, received, expected),
+function toHaveStyleRule(component, property, expected, options = {}) {
+  try {
+    const received = getStyleRule(component, property, options)
+
+    const pass =
+      !received && !expected && this.isNot
+        ? false
+        : matcherTest(received, expected)
+
+    return {
+      pass,
+      message: buildReturnMessage(
+        this.utils,
+        pass,
+        property,
+        received,
+        expected
+      ),
+    }
+  } catch (e) {
+    return {
+      pass: false,
+      message: () => e.message,
+    }
   }
 }
 


### PR DESCRIPTION
This PR attempts to fix https://github.com/styled-components/jest-styled-components/issues/117.

@MicheleBertoli I was not sure how you would want this utility to be exported. To stop it being run when calling `import 'jest-styled-components'` we could export it from its own file i.e. `import getStyleRule from 'jest-styled-components/getStyleRule', but it's less intuitive for users.

Let me know what you think. Thanks.