### PR TITLE
remove namespace of project's serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ This makes it possible to use this package with [specific-snapshot](https://gith
 import React from 'react'
 import styled from 'styled-components'
 import renderer from 'react-test-renderer'
-import { styleSheetSerializer } from "jest-styled-components/serializer"
+import styleSheetSerializer from "jest-styled-components/serializer"
 import { addSerializer } from "jest-specific-snapshot"
 
 addSerializer(styleSheetSerializer)

--- a/README.md
+++ b/README.md
@@ -323,7 +323,10 @@ test('it works', () => {
 ## Serializer
 
 The serializer can be imported separately from `jest-styled-components/serializer`.
-This makes it possible to use this package with [specific-snapshot](https://github.com/igor-dv/jest-specific-snapshot) and other libraries.
+
+### Per Snapshot
+
+It is possible to use this package with [specific-snapshot](https://github.com/igor-dv/jest-specific-snapshot) and other libraries.
 
 ```js
 import React from 'react'
@@ -343,6 +346,19 @@ test('it works', () => {
   expect(tree).toMatchSpecificSnapshot("./Button.snap")
 })
 ````
+
+### Jest Configuration
+
+Update your [Jest config](https://jestjs.io/docs/en/configuration) to include this serializer in the [`snapshotSerializers`](https://jestjs.io/docs/en/configuration#snapshotserializers-array-string) array property.
+
+```js
+// jest.config.js
+
+module.exports = {
+  // ...
+  snapshotSerializers: ['jest-styled-components/serializer'],
+};
+```
 
 # toHaveStyleRule
 

--- a/serializer/index.js
+++ b/serializer/index.js
@@ -1,3 +1,3 @@
 const styleSheetSerializer = require('../src/styleSheetSerializer')
 
-module.exports.styleSheetSerializer = styleSheetSerializer
+module.exports = styleSheetSerializer


### PR DESCRIPTION
This is a small PR to document how to use the project's serializer with Jest configuration.