### PR TITLE
Update Matchers interface

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,7 +12,7 @@ declare namespace jest {
     supports?: string;
   }
 
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     toHaveStyleRule(property: string, value?: Value, options?: Options): R;
   }
 }


### PR DESCRIPTION
the `Matchers` type of definitelytyped's jest package have been updated (see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jest/index.d.ts#L639 ), which causes a compilation error since the interfaces don't match anymore.

See: https://github.com/FormidableLabs/enzyme-matchers/issues/318 or https://github.com/testing-library/jest-dom/issues/152

This PR changes the type to match the new one.