### PR TITLE
Edited readme file to update global installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,15 +436,9 @@ import 'jest-styled-components/native'
 
 # Global installation
 
-It is possible to setup this package for all the tests using the [setupFilesAfterEnv](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array) option:
+It is possible to setup this package for all the tests:
 
-```js
-"jest": {
-  "setupFilesAfterEnv": ["./setupTest.js"]
-}
-```
-
-And import the library once in the `setupTest.js` as follows:
+Import the library once in the `src/setupTests.js` as follows:
 
 ```js
 import 'jest-styled-components'

--- a/README.md
+++ b/README.md
@@ -436,9 +436,7 @@ import 'jest-styled-components/native'
 
 # Global installation
 
-It is possible to setup this package for all the tests:
-
-Import the library once in the `src/setupTests.js` as follows:
+It is possible to setup this package for all the tests. Import the library once in the `src/setupTests.js` as follows:
 
 ```js
 import 'jest-styled-components'


### PR DESCRIPTION
The global installation section is outdated.
I saw the issue already open but no one addressed it so far.
https://github.com/styled-components/jest-styled-components/issues/237

Instructions fix is quite easy because when following these instructions, the error message will show displaying this message: 
`We detected setupFilesAfterEnv in your package.json. Remove it from Jest configuration, and put the initialization code in src/setupTests.js. This file will be loaded automatically.`