### PR TITLE
Fix toHaveStyleRule support classes with displayName prefix

### DIFF
--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -68,7 +68,7 @@ const getModifiedClassName = (className, staticClassName, modifier = "") => {
 };
 
 const hasClassNames = (classNames, selectors, options) => {
-  const staticClassNames = classNames.filter(x => x.startsWith("sc-"));
+  const staticClassNames = classNames.filter(x => /^(\w+-)?sc-\w+/.test(x));
 
   return classNames.some(className =>
     staticClassNames.some(staticClassName =>

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -68,7 +68,7 @@ const getModifiedClassName = (className, staticClassName, modifier = "") => {
 };
 
 const hasClassNames = (classNames, selectors, options) => {
-  const staticClassNames = classNames.filter(x => /^(\w+-)?sc-\w+/.test(x));
+  const staticClassNames = classNames.filter(x => /^(\w+-)?sc-/.test(x));
 
   return classNames.some(className =>
     staticClassNames.some(staticClassName =>

--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -68,7 +68,7 @@ const getModifiedClassName = (className, staticClassName, modifier = "") => {
 };
 
 const hasClassNames = (classNames, selectors, options) => {
-  const staticClassNames = classNames.filter(x => /^(\w+-)?sc-/.test(x));
+  const staticClassNames = classNames.filter(x => /^(\w+(-|_))?sc-/.test(x));
 
   return classNames.some(className =>
     staticClassNames.some(staticClassName =>

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -491,3 +491,14 @@ it("empty children", () => {
 
   toHaveStyleRule(<Wrapper />, "background", "papayawhip");
 });
+
+it("custom display name prefix", () => {
+  const Text = styled.span.withConfig({ displayName: 'Text__sc' })`
+    color: red;
+  `;
+  const Comp = styled(Text).withConfig({ displayName: 'Comp__Sub-sc' })`
+    background: papayawhip;
+  `;
+  toHaveStyleRule(<Comp />, "background", "papayawhip");
+  toHaveStyleRule(<Comp />, "color", "red");
+});


### PR DESCRIPTION
Fixes `toHaveStyleRule` support for classes with a `displayName` prefix from  babel-plugin-styled-components

Closes #290 #294