### PR TITLE
Remove object spread to continue Node LTS 10/12 support

### DIFF
--- a/src/native/toHaveStyleRule.js
+++ b/src/native/toHaveStyleRule.js
@@ -14,7 +14,7 @@ function toHaveStyleRule(component, property, expected) {
    * Merge all styles into one final style object and search for the desired
    * stylename against this object
    */
-  const mergedStyles = styles.reduce((acc, item) => ({ ...acc, ...item }), {})
+  const mergedStyles = styles.reduce((acc, item) => (Object.assign({}, acc, item )), {})
   const received = mergedStyles[camelCasedProperty]
   const pass =
     !received && !expected && this.isNot


### PR DESCRIPTION
replace object spread with object.assing to have support for the current node LTS versions (10/12) and avoid errors like `SyntaxError: Unexpected token ...`