### PR TITLE
Fix issue #317

### DIFF
--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -896,6 +896,32 @@ exports[`shallow with theme 1`] = `
 </button>
 `;
 
+exports[`should match the same snapshot rerendering the same element: first-render 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`;
+
+exports[`should match the same snapshot rerendering the same element: second-render 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`;
+
 exports[`strips unused styles: mount 1`] = `
 .c2 {
   color: blue;

--- a/test/styleSheetSerializer.spec.js
+++ b/test/styleSheetSerializer.spec.js
@@ -234,7 +234,7 @@ it('referring to other components', () => {
   const TextWithConditionalFormatting = styled.span`
     ${Container} & {
       color: yellow;
-      background-color: ${(props) => (props.error ? 'red' : 'green')};
+      background-color: ${props => (props.error ? 'red' : 'green')};
     }
   `;
 
@@ -299,6 +299,19 @@ it('referring to other unreferenced components', () => {
       <ReferencedLink>Styled, exciting Link</ReferencedLink>
     </div>
   );
+});
+
+it('should match the same snapshot rerendering the same element', () => {
+  const StyledDiv = styled.div`
+    color: palevioletred;
+    font-weight: bold;
+  `;
+
+  const {rerender, container} = render(<StyledDiv />);
+
+  expect(container).toMatchSnapshot('first-render');
+  rerender(<StyledDiv />);
+  expect(container).toMatchSnapshot('second-render');
 });
 
 it('allows to disable css snapshotting', () => {


### PR DESCRIPTION
After the first render the node are marked with KEY property.
Calling the rerender function of RTL the nodes remain marked and the print function will never call again.