### PR TITLE
Fix #350 - Strip styled components referenced in css by not used in the render

### DIFF
--- a/src/styleSheetSerializer.js
+++ b/src/styleSheetSerializer.js
@@ -49,8 +49,14 @@ const filterUnreferencedClassNames = (classNames, hashes) => classNames.filter(c
 const includesClassNames = (classNames, selectors) =>
   classNames.some(className => selectors.some(selector => selector.includes(className)));
 
+const includesUnknownClassNames = (classNames, selectors) =>
+  !selectors
+    .flatMap(selector => selector.split(' '))
+    .filter(chunk => chunk.includes('sc-'))
+    .every(chunk => classNames.some(className => chunk.includes(className)))
+
 const filterRules = classNames => rule =>
-  rule.type === 'rule' && includesClassNames(classNames, rule.selectors) && rule.declarations.length;
+  rule.type === 'rule' && !includesUnknownClassNames(classNames, rule.selectors) && includesClassNames(classNames, rule.selectors) && rule.declarations.length;
 
 const getAtRules = (ast, filter) =>
   ast.stylesheet.rules

--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -400,7 +400,7 @@ exports[`non-styled: shallow 1`] = `<div />`;
 exports[`null 1`] = `null`;
 
 exports[`referring to other components: mount 1`] = `
-.c1 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -414,18 +414,18 @@ exports[`referring to other components: mount 1`] = `
   color: palevioletred;
 }
 
-.c2 {
+.c4 {
   -webkit-transition: fill 0.25s;
   transition: fill 0.25s;
   width: 48px;
   height: 48px;
 }
 
-.c0:hover .c2 {
+.c2:hover .c4 {
   fill: rebeccapurple;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -437,62 +437,72 @@ exports[`referring to other components: mount 1`] = `
   line-height: 1.2;
 }
 
-.c3::before {
+.c5::before {
   content: '◀';
   margin: 0 10px;
 }
 
-.sc-fzXfLU .c4 {
+.c1 {
+  color: black;
+}
+
+.c0 .c6 {
   color: yellow;
   background-color: green;
 }
 
-.sc-fzXfLU .c5 {
+.c0 .c7 {
   color: yellow;
   background-color: red;
 }
 
-<styled.a
-  href="#"
->
-  <a
+<styled.div>
+  <div
     className="c0 c1"
-    href="#"
   >
-    <styled.svg>
-      <svg
-        className="c2"
-      />
-    </styled.svg>
-    <styled.span>
-      <span
-        className="c3"
-      >
-        Hovering my parent changes my style!
-      </span>
-    </styled.span>
-    <styled.span>
-      <span
-        className="c4"
-      >
-        I should be green
-      </span>
-    </styled.span>
-    <styled.span
-      error={true}
+    <styled.a
+      href="#"
     >
-      <span
-        className="c5"
+      <a
+        className="c2 c3"
+        href="#"
       >
-        I should be red
-      </span>
-    </styled.span>
-  </a>
-</styled.a>
+        <styled.svg>
+          <svg
+            className="c4"
+          />
+        </styled.svg>
+        <styled.span>
+          <span
+            className="c5"
+          >
+            Hovering my parent changes my style!
+          </span>
+        </styled.span>
+        <styled.span>
+          <span
+            className="c6"
+          >
+            I should be green
+          </span>
+        </styled.span>
+        <styled.span
+          error={true}
+        >
+          <span
+            className="c7"
+          >
+            I should be red
+          </span>
+        </styled.span>
+      </a>
+    </styled.a>
+  </div>
+</styled.div>
 `;
 
 exports[`referring to other components: react-test-renderer 1`] = `
-.c1 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -506,18 +516,18 @@ exports[`referring to other components: react-test-renderer 1`] = `
   color: palevioletred;
 }
 
-.c2 {
+.c4 {
   -webkit-transition: fill 0.25s;
   transition: fill 0.25s;
   width: 48px;
   height: 48px;
 }
 
-.c0:hover .c2 {
+.c2:hover .c4 {
   fill: rebeccapurple;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -529,48 +539,56 @@ exports[`referring to other components: react-test-renderer 1`] = `
   line-height: 1.2;
 }
 
-.c3::before {
+.c5::before {
   content: '◀';
   margin: 0 10px;
 }
 
-.sc-fzXfLU .c4 {
+.c1 {
+  color: black;
+}
+
+.c0 .c6 {
   color: yellow;
   background-color: green;
 }
 
-.sc-fzXfLU .c5 {
+.c0 .c7 {
   color: yellow;
   background-color: red;
 }
 
-<a
+<div
   className="c0 c1"
-  href="#"
 >
-  <svg
-    className="c2"
-  />
-  <span
-    className="c3"
+  <a
+    className="c2 c3"
+    href="#"
   >
-    Hovering my parent changes my style!
-  </span>
-  <span
-    className="c4"
-  >
-    I should be green
-  </span>
-  <span
-    className="c5"
-  >
-    I should be red
-  </span>
-</a>
+    <svg
+      className="c4"
+    />
+    <span
+      className="c5"
+    >
+      Hovering my parent changes my style!
+    </span>
+    <span
+      className="c6"
+    >
+      I should be green
+    </span>
+    <span
+      className="c7"
+    >
+      I should be red
+    </span>
+  </a>
+</div>
 `;
 
 exports[`referring to other components: react-testing-library 1`] = `
-.c1 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -584,18 +602,18 @@ exports[`referring to other components: react-testing-library 1`] = `
   color: palevioletred;
 }
 
-.c2 {
+.c4 {
   -webkit-transition: fill 0.25s;
   transition: fill 0.25s;
   width: 48px;
   height: 48px;
 }
 
-.c0:hover .c2 {
+.c2:hover .c4 {
   fill: rebeccapurple;
 }
 
-.c3 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -607,44 +625,52 @@ exports[`referring to other components: react-testing-library 1`] = `
   line-height: 1.2;
 }
 
-.c3::before {
+.c5::before {
   content: '◀';
   margin: 0 10px;
 }
 
-.sc-fzXfLU .c4 {
+.c1 {
+  color: black;
+}
+
+.c0 .c6 {
   color: yellow;
   background-color: green;
 }
 
-.sc-fzXfLU .c5 {
+.c0 .c7 {
   color: yellow;
   background-color: red;
 }
 
-<a
+<div
   class="c0 c1"
-  href="#"
 >
-  <svg
-    class="c2"
-  />
-  <span
-    class="c3"
+  <a
+    class="c2 c3"
+    href="#"
   >
-    Hovering my parent changes my style!
-  </span>
-  <span
-    class="c4"
-  >
-    I should be green
-  </span>
-  <span
-    class="c5"
-  >
-    I should be red
-  </span>
-</a>
+    <svg
+      class="c4"
+    />
+    <span
+      class="c5"
+    >
+      Hovering my parent changes my style!
+    </span>
+    <span
+      class="c6"
+    >
+      I should be green
+    </span>
+    <span
+      class="c7"
+    >
+      I should be red
+    </span>
+  </a>
+</div>
 `;
 
 exports[`referring to other unreferenced components: mount 1`] = `
@@ -715,6 +741,82 @@ exports[`shallow with theme 1`] = `
 >
   Themed
 </button>
+`;
+
+exports[`strips unused styles: mount 1`] = `
+.c2 {
+  color: blue;
+}
+
+.c0 {
+  font-size: 16px;
+}
+
+.c0 .c1 {
+  text-align: right;
+}
+
+<styled.div>
+  <div
+    className="c0"
+  >
+    <styled.div>
+      <div
+        className="c1 c2"
+      >
+        A container that has styles for an unused child
+      </div>
+    </styled.div>
+  </div>
+</styled.div>
+`;
+
+exports[`strips unused styles: react-test-renderer 1`] = `
+.c2 {
+  color: blue;
+}
+
+.c0 {
+  font-size: 16px;
+}
+
+.c0 .c1 {
+  text-align: right;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1 c2"
+  >
+    A container that has styles for an unused child
+  </div>
+</div>
+`;
+
+exports[`strips unused styles: react-testing-library 1`] = `
+.c2 {
+  color: blue;
+}
+
+.c0 {
+  font-size: 16px;
+}
+
+.c0 .c1 {
+  text-align: right;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    A container that has styles for an unused child
+  </div>
+</div>
 `;
 
 exports[`supported css: mount 1`] = `

--- a/test/styleSheetSerializer.spec.js
+++ b/test/styleSheetSerializer.spec.js
@@ -238,18 +238,50 @@ it('referring to other components', () => {
   `;
 
   const component = (
-    <Link href="#">
-      <Icon />
-      <Label>Hovering my parent changes my style!</Label>
-      <TextWithConditionalFormatting>I should be green</TextWithConditionalFormatting>
-      <TextWithConditionalFormatting error>I should be red</TextWithConditionalFormatting>
-    </Link>
+    <Container>
+      <Link href="#">
+        <Icon />
+        <Label>Hovering my parent changes my style!</Label>
+        <TextWithConditionalFormatting>I should be green</TextWithConditionalFormatting>
+        <TextWithConditionalFormatting error>I should be red</TextWithConditionalFormatting>
+      </Link>
+    </Container>
   );
 
   expect(renderer.create(component).toJSON()).toMatchSnapshot('react-test-renderer');
   expect(mount(component)).toMatchSnapshot('mount');
   expect(render(component).container.firstChild).toMatchSnapshot('react-testing-library');
 });
+
+it('strips unused styles', () => {
+  const BlueText = styled.div`
+    color: blue;
+  `;
+  const RedText = styled.div`
+    color: red;
+  `;
+
+  const FancyText = styled.div`
+    font-size: 16px;
+
+    ${BlueText} {
+      text-align: right;
+    }
+    ${RedText} {
+      text-align: center;
+    }
+  `;
+
+  const component = (
+    <FancyText>
+      <BlueText>A container that has styles for an unused child</BlueText>
+    </FancyText>
+  );
+
+  expect(renderer.create(component).toJSON()).toMatchSnapshot('react-test-renderer');
+  expect(mount(component)).toMatchSnapshot('mount');
+  expect(render(component).container.firstChild).toMatchSnapshot('react-testing-library');
+})
 
 it('referring to other unreferenced components', () => {
   const UnreferencedLink = styled.a`


### PR DESCRIPTION
This PR removes CSS rules referencing unused styled components from the snapshot. See #350 for details.

The approach I took here was adding a filter for CSS rules which contain references to unknown styled component class names.

Note that this also fixes a test; "referring to other components", which was incorrectly passing, as it contained a reference to a container element that was never used.