### PR TITLE
add snapshot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,26 @@ test('it works', () => {
   const tree = renderer.create(<Button />).toJSON()
   expect(tree).toMatchSpecificSnapshot("./Button.snap")
 })
-````
+```
+
+## Serializer Options
+
+The serializer can be configured to control the snapshot output.
+
+```js
+import { render } from '@testing-library/react'
+import { setStyleSheetSerializerOptions } from 'jest-styled-components/serializer'
+
+setStyleSheetSerializerOptions({
+  addStyles: false,
+  classNameFormatter: (index) => `styled${index}`
+});
+
+test('it works', () => {
+  const { container } = render(<Button />)
+  expect(container.firstChild).toMatchSnapshot()
+})
+```
 
 # toHaveStyleRule
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "typings"
   ],
   "repository": "git@github.com:styled-components/jest-styled-components.git",
+  "bugs": {
+    "url": "https://github.com/styled-components/jest-styled-components/issues"
+  },
   "author": "Michele Bertoli",
   "license": "MIT",
   "scripts": {

--- a/serializer/index.js
+++ b/serializer/index.js
@@ -1,3 +1,4 @@
 const styleSheetSerializer = require('../src/styleSheetSerializer')
 
 module.exports.styleSheetSerializer = styleSheetSerializer
+module.exports.setStyleSheetSerializerOptions = styleSheetSerializer.setStyleSheetSerializerOptions;

--- a/test/__snapshots__/styleSheetSerializer.spec.js.snap
+++ b/test/__snapshots__/styleSheetSerializer.spec.js.snap
@@ -1,5 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows to disable css snapshotting: mount 1`] = `
+<div>
+  <styled.div>
+    <div
+      className="c0"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+  <styled.div>
+    <div
+      className="c1"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+</div>
+`;
+
+exports[`allows to disable css snapshotting: react-test-renderer 1`] = `
+<div>
+  <div
+    className="c0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    className="c1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to disable css snapshotting: react-testing-library 1`] = `
+<div>
+  <div
+    class="c0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    class="c1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to disable css snapshotting: shallow 1`] = `
+<div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter: mount 1`] = `
+.styledComponent0 {
+  color: red;
+}
+
+.styledComponent1 {
+  color: green;
+}
+
+<div>
+  <styled.div>
+    <div
+      className="styledComponent0"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+  <styled.div>
+    <div
+      className="styledComponent1"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter: react-test-renderer 1`] = `
+.styledComponent0 {
+  color: red;
+}
+
+.styledComponent1 {
+  color: green;
+}
+
+<div>
+  <div
+    className="styledComponent0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    className="styledComponent1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter: react-testing-library 1`] = `
+.styledComponent0 {
+  color: red;
+}
+
+.styledComponent1 {
+  color: green;
+}
+
+<div>
+  <div
+    class="styledComponent0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    class="styledComponent1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter: shallow 1`] = `
+<div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+</div>
+`;
+
 exports[`any component: mount 1`] = `
 .c0 {
   color: palevioletred;

--- a/test/styleSheetSerializer.spec.js
+++ b/test/styleSheetSerializer.spec.js
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 import React from 'react';
 import renderer from 'react-test-renderer';
 import styled, { ThemeContext, ThemeProvider } from 'styled-components';
+import {setStyleSheetSerializerOptions} from '../serializer';
 
 const toMatchSnapshot = component => {
   expect(renderer.create(component).toJSON()).toMatchSnapshot('react-test-renderer');
@@ -264,6 +265,39 @@ it('referring to other unreferenced components', () => {
   toMatchSnapshot(
     <div>
       <ReferencedLink>Styled, exciting Link</ReferencedLink>
+    </div>
+  );
+});
+
+it('allows to disable css snapshotting', () => {
+  setStyleSheetSerializerOptions({ addStyles: false })
+  const A = styled.div`
+    color: red;
+  `; const B = styled.div`
+    color: red;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <A>Styled, exciting div</A>
+      <B>Styled, exciting div</B>
+    </div>
+  );
+});
+
+it('allows to set a css classNameFormatter', () => {
+  setStyleSheetSerializerOptions({ classNameFormatter: (index) => `styledComponent${index}`  })
+  const A = styled.div`
+    color: red;
+  `;
+  const B = styled.div`
+    color: green;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <A>Styled, exciting div</A>
+      <B>Styled, exciting div</B>
     </div>
   );
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,4 +21,11 @@ declare global {
   }
 }
 
-export declare const styleSheetSerializer: Exclude<Plugin, NewPlugin>;
+export interface StyledComponentsSerializerOptions { 
+  addStyles?: boolean, 
+  classNameFormatter?: (index: number) => string 
+} 
+
+export declare const styleSheetSerializer: Exclude<Plugin, NewPlugin> & { 
+  setStyleSheetSerializerOptions: (options?: StyledComponentsSerializerOptions) => void 
+};


### PR DESCRIPTION
We are using `jest-styled-components` in a large codebase and it works perfectly.  
However sometimes we would love to have more control over the snapshots generation.

This pr shows how a `setStyleSheetSerializerOptions` might be added which would allow:

- generate snapshots with css
- generate snapshots without css
- generate snapshots without css but still make use of `toHaveStyleRule`
- allows to format the className e.g. `styledComponent0` instead of `c0`

Example usage:

```tsx
import 'jest-styled-components';
import { setStyleSheetSerializerOptions } from 'jest-styled-components/serializer';

describe('style tests', () => {
  test('it renders correct styles for X', () => { 
    const { container } = render(<Button />) 
    expect(container.firstChild).toMatchSnapshot()})
  })
}) 

describe('other tests', () => {
  beforeEach(() => {
    setStyleSheetSerializerOptions({ addStyles: false })
  });
  test('it renders correct markup for case X', () => { 
    const { container } = render(<Button />) 
    expect(container.firstChild).toMatchSnapshot()})
  })
}) 
```

I am very open to feedback and would love to know what you think