### PR TITLE
Remove sc style nodes on cleanup

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,13 @@ const sheet = mainSheet || masterSheet;
 const isServer = () => typeof document === 'undefined';
 
 const resetStyleSheet = () => {
+  if (!isServer()) {
+    const scStyles = document.querySelectorAll('style[data-styled-version]')
+    for (const item of scStyles) {
+      item.parentElement.removeChild(item)
+    }
+  }
+
   sheet.names = new Map();
   sheet.clearTag();
 };

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,9 +1,10 @@
-const {
-  __PRIVATE__: { mainSheet, masterSheet },
-} = require('styled-components');
+import styled, { __PRIVATE__ } from 'styled-components'
+import { render } from '@testing-library/react';
+import React from 'react'
+import { getHashes, resetStyleSheet } from '../src/utils';
+import { expect } from '@jest/globals';
 
-const { getHashes } = require('../src/utils');
-
+const { mainSheet, masterSheet } = __PRIVATE__
 const sheet = mainSheet || masterSheet;
 
 it('extracts hashes', () => {
@@ -36,3 +37,23 @@ it('extracts hashes', () => {
 
   expect(getHashes()).toEqual(['sc-1', 'a', 'sc-2', 'b', 'c', 'sc-3', 'd', 'e']);
 });
+
+it('resets style sheets', () => {
+  const Component = styled.div`
+    background-color: orange;
+  `
+
+  render(<Component />)
+
+  expect(
+    document.querySelectorAll('style[data-styled-version]').length,
+  ).not.toBe(0)
+  expect(sheet.names.size).not.toBe(0)
+
+  resetStyleSheet()
+
+  expect(
+    document.querySelectorAll('style[data-styled-version]').length,
+  ).toBe(0)
+  expect(sheet.names.size).toBe(0)
+})

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -2,7 +2,6 @@ import styled, { __PRIVATE__ } from 'styled-components'
 import { render } from '@testing-library/react';
 import React from 'react'
 import { getHashes, resetStyleSheet } from '../src/utils';
-import { expect } from '@jest/globals';
 
 const { mainSheet, masterSheet } = __PRIVATE__
 const sheet = mainSheet || masterSheet;


### PR DESCRIPTION
On cleanup, `jest-styled-components` resets `styled-components` internal state, but leaves styles in document head. This leads to significant jsdom performance degradation in large tests.

This PR improves cleanup, so that `style[data-styled-version]` nodes are removed from the document.