### PR TITLE
fix: use correct repository syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src",
     "typings"
   ],
-  "repository": "git@github.com:styled-components/jest-styled-components.git",
+  "repository": "github:styled-components/jest-styled-components",
   "bugs": {
     "url": "https://github.com/styled-components/jest-styled-components/issues"
   },


### PR DESCRIPTION
Currently the `repository` value seems to be invalid and therefore it's not shown on npmjs.com. See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository for more info. This should make it easier for users to find the GitHub Repo while browsing npm.