### PR TITLE
Fix issue #403 with snake case filenames

### DIFF
--- a/src/toHaveStyleRule.js
+++ b/src/toHaveStyleRule.js
@@ -4,7 +4,7 @@ const shouldDive = (node) => typeof node.dive === 'function' && typeof node.type
 
 const isTagWithClassName = (node) => node.exists() && node.prop('className') && typeof node.type() === 'string';
 
-const isStyledClass = (className) => /^(\w+(-|_))?sc-/.test(className);
+const isStyledClass = (className) => /(_|-)+sc-.+|^sc-/.test(className);
 
 const hasClassName = (node) =>
   node.length > 0 &&

--- a/test/toHaveStyleRule.spec.js
+++ b/test/toHaveStyleRule.spec.js
@@ -493,3 +493,12 @@ it('custom display name prefix', () => {
   toHaveStyleRule(<Comp />, 'background', 'papayawhip');
   toHaveStyleRule(<Comp />, 'color', 'red');
 });
+
+it("supports snake case display name prefix", () => {
+  const Text = styled.span`
+    color: blue;
+  `;
+  Text.styledComponentId = `test-case-${Text.styledComponentId}`;
+
+  toHaveStyleRule(<Text />, "color", "blue");
+});


### PR DESCRIPTION
Fixes #403 by extending the regex for the `isStyledClass` function to support look for the patterns `-sc-`or `_sc-` anywhere in a class name or `sc-` at the start of class name. This should allow toHaveStyleRule to function with classNames that contain a filename for a component within them even when that filename is snake case.