### PR TITLE
perf(utils): only extract HTML once during while loop

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,8 @@ const extract = (regex) => {
   let style = '';
   let matches;
 
-  while ((matches = regex.exec(getHTML())) !== null) {
+  const html = getHTML();
+  while ((matches = regex.exec(html)) !== null) {
     style += `${matches[1]} `;
   }
 


### PR DESCRIPTION
Currently this loop calls getHTML() on each cycle, when the value doesn't or shouldn't change. This extracts it to a separate variable so it's only called once.