### PR TITLE
add support for @starting-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "styled-components": "^6.0.9"
   },
   "dependencies": {
-    "@adobe/css-tools": "^4.0.1"
+    "@adobe/css-tools": "^4.4.0"
   },
   "peerDependencies": {
     "styled-components": ">= 5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@adobe/css-tools@^4.0.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.1.tgz#abfccb8ca78075a2b6187345c26243c1a0842f28"
-  integrity sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==
+"@adobe/css-tools@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.0.tgz#728c484f4e10df03d5a3acd0d8adcbbebff8ad63"
+  integrity sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"


### PR DESCRIPTION
**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Upgraded the `@adobe/css-tools` dependency to include the fix for parsing the `@starting-style` CSS feature, which was causing a "missing '}'" error.

**Why**:

<!-- Why are these changes necessary? -->

The current version of `@adobe/css-tools` used by `jest-styled-components` fails to parse the `@starting-style` CSS feature, resulting in a parsing error. The upgrade includes a fix for this issue, allowing for the correct parsing of CSS files using `@starting-style`.

**How**:

<!-- How were these changes implemented? -->

The changes were implemented by updating the `package.json` file to use the latest version of `@adobe/css-tools`, which includes the fix from the PR I submitted to `@adobe/css-tools` (https://github.com/adobe/css-tools/pull/323).

<!-- feel free to add additional comments -->

**Additional Comments**:

Unfortunately, I could not add a test case for the `@starting-style` feature because `jsdom 20` uses `CSSOM` for CSS parsing, which also has a similar issue. I submitted a PR to fix this issue in `CSSOM` (https://github.com/rrweb-io/CSSOM/pull/1), but the latest version of `jsdom` cannot be merged into `jest-environment-jsdom` to maintain Node 16 support.

For reference, I have already submitted a similar PR to `testing-library/jest-dom` addressing the same issue: https://github.com/testing-library/jest-dom/pull/602.