### PR TITLE
Allow vitest in non-globals mode

### DIFF
--- a/.vitest.config.ts
+++ b/.vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    setupFiles: [
+      //   "<rootDir>/test/__mocks__/requestAnimationFrame.js",
+      "test/setup_vitest.js",
+      "./vitest.js",
+    ],
+    snapshotSerializers: ["enzyme-to-json/serializer"],
+    environment: "jsdom",
+    // testPathIgnorePatterns: ["<rootDir>/test/native", "<rootDir>/test/preact"],
+
+    include: ["**/*.vitest.jsx"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "native",
     "serializer",
     "src",
-    "typings"
+    "typings",
+    "vitest.js"
   ],
   "repository": "github:styled-components/jest-styled-components",
   "bugs": {
@@ -17,11 +18,12 @@
   "author": "Michele Bertoli",
   "license": "MIT",
   "scripts": {
-    "test": "yarn test:web && yarn test:native && yarn test:preact",
+    "test": "yarn test:web && yarn test:native && yarn test:preact && yarn test:vitest",
     "test:web": "jest --color",
     "test:web:watch": "jest --watch",
     "test:native": "jest --color --config .jest.native.json",
-    "test:preact": "jest --color --config .jest.preact.json"
+    "test:preact": "jest --color --config .jest.preact.json",
+    "test:vitest": "yarn vitest --config .vitest.config.ts"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,7 @@
-const toHaveStyleRule = require('./toHaveStyleRule');
-const styleSheetSerializer = require('./styleSheetSerializer');
-const { resetStyleSheet } = require('./utils');
+const styleSheetSerializer = require("./styleSheetSerializer");
+const init = require("./init");
 
-global.beforeEach(resetStyleSheet);
-
-expect.addSnapshotSerializer(styleSheetSerializer);
-expect.extend({ toHaveStyleRule });
+init(global.beforeEach, expect);
 
 module.exports = {
   styleSheetSerializer,

--- a/src/init.js
+++ b/src/init.js
@@ -1,0 +1,13 @@
+const toHaveStyleRule = require('./toHaveStyleRule');
+const styleSheetSerializer = require('./styleSheetSerializer');
+const { resetStyleSheet } = require('./utils');
+
+function init(beforeEach, expect) {
+    beforeEach(resetStyleSheet);
+
+    expect.addSnapshotSerializer(styleSheetSerializer);
+    expect.extend({ toHaveStyleRule });
+
+}
+
+module.exports = init

--- a/test/__snapshots__/styleSheetSerializer.vitest.jsx.snap
+++ b/test/__snapshots__/styleSheetSerializer.vitest.jsx.snap
@@ -1,0 +1,1308 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`allows to disable css snapshotting > mount 1`] = `
+<div>
+  <styled.div>
+    <div
+      className="c0"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+  <styled.div>
+    <div
+      className="c1"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+</div>
+`;
+
+exports[`allows to disable css snapshotting > react-test-renderer 1`] = `
+<div>
+  <div
+    className="c0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    className="c1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to disable css snapshotting > react-testing-library 1`] = `
+<div>
+  <div
+    class="c0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    class="c1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to disable css snapshotting > shallow 1`] = `
+<div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter > mount 1`] = `
+.styledComponent0 {
+  color: red;
+}
+
+.styledComponent1 {
+  color: green;
+}
+
+<div>
+  <styled.div>
+    <div
+      className="styledComponent0"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+  <styled.div>
+    <div
+      className="styledComponent1"
+    >
+      Styled, exciting div
+    </div>
+  </styled.div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter > react-test-renderer 1`] = `
+.styledComponent0 {
+  color: red;
+}
+
+.styledComponent1 {
+  color: green;
+}
+
+<div>
+  <div
+    className="styledComponent0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    className="styledComponent1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter > react-testing-library 1`] = `
+.styledComponent0 {
+  color: red;
+}
+
+.styledComponent1 {
+  color: green;
+}
+
+<div>
+  <div
+    class="styledComponent0"
+  >
+    Styled, exciting div
+  </div>
+  <div
+    class="styledComponent1"
+  >
+    Styled, exciting div
+  </div>
+</div>
+`;
+
+exports[`allows to set a css classNameFormatter > shallow 1`] = `
+<div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+  <styled.div>
+    Styled, exciting div
+  </styled.div>
+</div>
+`;
+
+exports[`any component > mount 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <Link>
+    <a>
+      Unstyled, boring Link
+    </a>
+  </Link>
+  <br />
+  <Styled(Link)>
+    <Link
+      className="c0"
+    >
+      <a
+        className="c0"
+      >
+        Styled, exciting Link
+      </a>
+    </Link>
+  </Styled(Link)>
+</div>
+`;
+
+exports[`any component > react-test-renderer 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <a>
+    Unstyled, boring Link
+  </a>
+  <br />
+  <a
+    className="c0"
+  >
+    Styled, exciting Link
+  </a>
+</div>
+`;
+
+exports[`any component > react-testing-library 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <a>
+    Unstyled, boring Link
+  </a>
+  <br />
+  <a
+    class="c0"
+  >
+    Styled, exciting Link
+  </a>
+</div>
+`;
+
+exports[`any component > shallow 1`] = `
+<div>
+  <Link>
+    Unstyled, boring Link
+  </Link>
+  <br />
+  <Styled(Link)>
+    Styled, exciting Link
+  </Styled(Link)>
+</div>
+`;
+
+exports[`attaching additional props > mount 1`] = `
+.c0 {
+  color: red;
+}
+
+<styled.div>
+  <div
+    className="c0 div"
+  />
+</styled.div>
+`;
+
+exports[`attaching additional props > react-test-renderer 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  className="c0 div"
+/>
+`;
+
+exports[`attaching additional props > react-testing-library 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  class="c0 div"
+/>
+`;
+
+exports[`attaching additional props > shallow 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  className="c0 div"
+/>
+`;
+
+exports[`basic > mount 1`] = `
+.c0 {
+  padding: 4em;
+  background: papayawhip;
+}
+
+.c1 {
+  font-size: 1.5em;
+  text-align: center;
+  color: palevioletred;
+}
+
+<styled.section>
+  <section
+    className="c0"
+  >
+    <styled.h1>
+      <h1
+        className="c1"
+      >
+        Hello World, this is my first styled component!
+      </h1>
+    </styled.h1>
+  </section>
+</styled.section>
+`;
+
+exports[`basic > react-test-renderer 1`] = `
+.c0 {
+  padding: 4em;
+  background: papayawhip;
+}
+
+.c1 {
+  font-size: 1.5em;
+  text-align: center;
+  color: palevioletred;
+}
+
+<section
+  className="c0"
+>
+  <h1
+    className="c1"
+  >
+    Hello World, this is my first styled component!
+  </h1>
+</section>
+`;
+
+exports[`basic > react-testing-library 1`] = `
+.c0 {
+  padding: 4em;
+  background: papayawhip;
+}
+
+.c1 {
+  font-size: 1.5em;
+  text-align: center;
+  color: palevioletred;
+}
+
+<section
+  class="c0"
+>
+  <h1
+    class="c1"
+  >
+    Hello World, this is my first styled component!
+  </h1>
+</section>
+`;
+
+exports[`basic > shallow 1`] = `
+.c0 {
+  padding: 4em;
+  background: papayawhip;
+}
+
+<section
+  className="c0"
+>
+  <styled.h1>
+    Hello World, this is my first styled component!
+  </styled.h1>
+</section>
+`;
+
+exports[`duplicated components > mount 1`] = `
+.c0 {
+  color: red;
+}
+
+.c1 {
+  color: green;
+}
+
+<div>
+  <styled.div>
+    <div
+      className="c0"
+    />
+  </styled.div>
+   
+  <styled.div>
+    <div
+      className="c0"
+    />
+  </styled.div>
+   
+  <styled.div>
+    <div
+      className="c1"
+    />
+  </styled.div>
+</div>
+`;
+
+exports[`duplicated components > react-test-renderer 1`] = `
+.c0 {
+  color: red;
+}
+
+.c1 {
+  color: green;
+}
+
+<div>
+  <div
+    className="c0"
+  />
+   
+  <div
+    className="c0"
+  />
+   
+  <div
+    className="c1"
+  />
+</div>
+`;
+
+exports[`duplicated components > react-testing-library 1`] = `
+.c0 {
+  color: red;
+}
+
+.c1 {
+  color: green;
+}
+
+<div>
+  <div
+    class="c0"
+  />
+   
+  <div
+    class="c0"
+  />
+   
+  <div
+    class="c1"
+  />
+</div>
+`;
+
+exports[`duplicated components > shallow 1`] = `
+<div>
+  <styled.div />
+   
+  <styled.div />
+   
+  <styled.div />
+</div>
+`;
+
+exports[`empty style > mount 1`] = `
+<styled.div>
+  <div
+    className=""
+  />
+</styled.div>
+`;
+
+exports[`empty style > react-test-renderer 1`] = `
+<div
+  className=""
+/>
+`;
+
+exports[`empty style > react-testing-library 1`] = `
+<div
+  class=""
+/>
+`;
+
+exports[`empty style > shallow 1`] = `
+<div
+  className=""
+/>
+`;
+
+exports[`included class name > mount 1`] = `
+.c0 {
+  color: red;
+}
+
+<styled.div>
+  <div
+    className="c0 i"
+  />
+</styled.div>
+`;
+
+exports[`included class name > react-test-renderer 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  className="c0 i"
+/>
+`;
+
+exports[`included class name > react-testing-library 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  class="c0 i"
+/>
+`;
+
+exports[`included class name > shallow 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  className="c0 i"
+/>
+`;
+
+exports[`leading white spaces > mount 1`] = `
+<Div>
+  <div
+    className="  div"
+  />
+</Div>
+`;
+
+exports[`leading white spaces > react-test-renderer 1`] = `
+<div
+  className="  div"
+/>
+`;
+
+exports[`leading white spaces > react-testing-library 1`] = `
+<div
+  class="  div"
+/>
+`;
+
+exports[`leading white spaces > shallow 1`] = `
+<div
+  className="  div"
+/>
+`;
+
+exports[`non-styled > mount 1`] = `<div />`;
+
+exports[`non-styled > react-test-renderer 1`] = `<div />`;
+
+exports[`non-styled > react-testing-library 1`] = `<div />`;
+
+exports[`non-styled > shallow 1`] = `<div />`;
+
+exports[`null 1`] = `null`;
+
+exports[`referring to other components > mount 1`] = `
+.c3 {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background: papayawhip;
+  color: palevioletred;
+}
+
+.c4 {
+  transition: fill 0.25s;
+  width: 48px;
+  height: 48px;
+}
+
+.c2:hover .c4 {
+  fill: rebeccapurple;
+}
+
+.c5 {
+  display: flex;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.c5::before {
+  content: "◀";
+  margin: 0 10px;
+}
+
+.c1 {
+  color: black;
+}
+
+.c0 .c6 {
+  color: yellow;
+  background-color: green;
+}
+
+.c0 .c7 {
+  color: yellow;
+  background-color: red;
+}
+
+<styled.div>
+  <div
+    className="c0 c1"
+  >
+    <styled.a
+      href="#"
+    >
+      <a
+        className="c2 c3"
+        href="#"
+      >
+        <styled.svg>
+          <svg
+            className="c4"
+          />
+        </styled.svg>
+        <styled.span>
+          <span
+            className="c5"
+          >
+            Hovering my parent changes my style!
+          </span>
+        </styled.span>
+        <styled.span>
+          <span
+            className="c6"
+          >
+            I should be green
+          </span>
+        </styled.span>
+        <styled.span
+          error={true}
+        >
+          <span
+            className="c7"
+            error={true}
+          >
+            I should be red
+          </span>
+        </styled.span>
+      </a>
+    </styled.a>
+  </div>
+</styled.div>
+`;
+
+exports[`referring to other components > react-test-renderer 1`] = `
+.c3 {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background: papayawhip;
+  color: palevioletred;
+}
+
+.c4 {
+  transition: fill 0.25s;
+  width: 48px;
+  height: 48px;
+}
+
+.c2:hover .c4 {
+  fill: rebeccapurple;
+}
+
+.c5 {
+  display: flex;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.c5::before {
+  content: "◀";
+  margin: 0 10px;
+}
+
+.c1 {
+  color: black;
+}
+
+.c0 .c6 {
+  color: yellow;
+  background-color: green;
+}
+
+.c0 .c7 {
+  color: yellow;
+  background-color: red;
+}
+
+<div
+  className="c0 c1"
+>
+  <a
+    className="c2 c3"
+    href="#"
+  >
+    <svg
+      className="c4"
+    />
+    <span
+      className="c5"
+    >
+      Hovering my parent changes my style!
+    </span>
+    <span
+      className="c6"
+    >
+      I should be green
+    </span>
+    <span
+      className="c7"
+      error={true}
+    >
+      I should be red
+    </span>
+  </a>
+</div>
+`;
+
+exports[`referring to other components > react-testing-library 1`] = `
+.c3 {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  background: papayawhip;
+  color: palevioletred;
+}
+
+.c4 {
+  transition: fill 0.25s;
+  width: 48px;
+  height: 48px;
+}
+
+.c2:hover .c4 {
+  fill: rebeccapurple;
+}
+
+.c5 {
+  display: flex;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.c5::before {
+  content: "◀";
+  margin: 0 10px;
+}
+
+.c1 {
+  color: black;
+}
+
+.c0 .c6 {
+  color: yellow;
+  background-color: green;
+}
+
+.c0 .c7 {
+  color: yellow;
+  background-color: red;
+}
+
+<div
+  class="c0 c1"
+>
+  <a
+    class="c2 c3"
+    href="#"
+  >
+    <svg
+      class="c4"
+    />
+    <span
+      class="c5"
+    >
+      Hovering my parent changes my style!
+    </span>
+    <span
+      class="c6"
+    >
+      I should be green
+    </span>
+    <span
+      class="c7"
+    >
+      I should be red
+    </span>
+  </a>
+</div>
+`;
+
+exports[`referring to other unreferenced components > mount 1`] = `
+.c0 {
+  font-size: 1.5em;
+}
+
+.c1 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <Styled(styled.a)>
+    <a
+      className="c0 c1"
+    >
+      Styled, exciting Link
+    </a>
+  </Styled(styled.a)>
+</div>
+`;
+
+exports[`referring to other unreferenced components > react-test-renderer 1`] = `
+.c0 {
+  font-size: 1.5em;
+}
+
+.c1 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <a
+    className="c0 c1"
+  >
+    Styled, exciting Link
+  </a>
+</div>
+`;
+
+exports[`referring to other unreferenced components > react-testing-library 1`] = `
+.c0 {
+  font-size: 1.5em;
+}
+
+.c1 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <a
+    class="c0 c1"
+  >
+    Styled, exciting Link
+  </a>
+</div>
+`;
+
+exports[`referring to other unreferenced components > shallow 1`] = `
+<div>
+  <Styled(styled.a)>
+    Styled, exciting Link
+  </Styled(styled.a)>
+</div>
+`;
+
+exports[`shallow with theme 1`] = `
+.c0 {
+  color: mediumseagreen;
+}
+
+<button
+  className="c0"
+>
+  Themed
+</button>
+`;
+
+exports[`should match the same snapshot rerendering the same element > first-render 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`;
+
+exports[`should match the same snapshot rerendering the same element > second-render 1`] = `
+.c0 {
+  color: palevioletred;
+  font-weight: bold;
+}
+
+<div>
+  <div
+    class="c0"
+  />
+</div>
+`;
+
+exports[`strips unused styles > mount 1`] = `
+.c2 {
+  color: blue;
+}
+
+.c0 {
+  font-size: 16px;
+}
+
+.c0 .c1 {
+  text-align: right;
+}
+
+<styled.div>
+  <div
+    className="c0"
+  >
+    <styled.div>
+      <div
+        className="c1 c2"
+      >
+        A container that has styles for an unused child
+      </div>
+    </styled.div>
+  </div>
+</styled.div>
+`;
+
+exports[`strips unused styles > react-test-renderer 1`] = `
+.c2 {
+  color: blue;
+}
+
+.c0 {
+  font-size: 16px;
+}
+
+.c0 .c1 {
+  text-align: right;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1 c2"
+  >
+    A container that has styles for an unused child
+  </div>
+</div>
+`;
+
+exports[`strips unused styles > react-testing-library 1`] = `
+.c2 {
+  color: blue;
+}
+
+.c0 {
+  font-size: 16px;
+}
+
+.c0 .c1 {
+  text-align: right;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 c2"
+  >
+    A container that has styles for an unused child
+  </div>
+</div>
+`;
+
+exports[`supported css > mount 1`] = `
+.c0 {
+  padding: 2em 1em;
+  background: papayawhip;
+}
+
+.c0:hover {
+  background: palevioletred;
+}
+
+.c0 >p {
+  text-decoration: underline;
+}
+
+html.test .c0 {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .c0 {
+    background: tomato;
+  }
+
+  .c0:hover {
+    background: yellow;
+  }
+}
+
+<styled.div>
+  <div
+    className="c0"
+  >
+    <p>
+      Hello World!
+    </p>
+  </div>
+</styled.div>
+`;
+
+exports[`supported css > react-test-renderer 1`] = `
+.c0 {
+  padding: 2em 1em;
+  background: papayawhip;
+}
+
+.c0:hover {
+  background: palevioletred;
+}
+
+.c0 >p {
+  text-decoration: underline;
+}
+
+html.test .c0 {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .c0 {
+    background: tomato;
+  }
+
+  .c0:hover {
+    background: yellow;
+  }
+}
+
+<div
+  className="c0"
+>
+  <p>
+    Hello World!
+  </p>
+</div>
+`;
+
+exports[`supported css > react-testing-library 1`] = `
+.c0 {
+  padding: 2em 1em;
+  background: papayawhip;
+}
+
+.c0:hover {
+  background: palevioletred;
+}
+
+.c0 >p {
+  text-decoration: underline;
+}
+
+html.test .c0 {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .c0 {
+    background: tomato;
+  }
+
+  .c0:hover {
+    background: yellow;
+  }
+}
+
+<div
+  class="c0"
+>
+  <p>
+    Hello World!
+  </p>
+</div>
+`;
+
+exports[`supported css > shallow 1`] = `
+.c0 {
+  padding: 2em 1em;
+  background: papayawhip;
+}
+
+.c0:hover {
+  background: palevioletred;
+}
+
+.c0 >p {
+  text-decoration: underline;
+}
+
+html.test .c0 {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .c0 {
+    background: tomato;
+  }
+
+  .c0:hover {
+    background: yellow;
+  }
+}
+
+<div
+  className="c0"
+>
+  <p>
+    Hello World!
+  </p>
+</div>
+`;
+
+exports[`theming > mount 1`] = `
+.c0 {
+  font-size: 1em;
+  margin: 1em;
+  padding: 0.25em 1em;
+  border-radius: 3px;
+  color: palevioletred;
+  border: 2px solid palevioletred;
+}
+
+.c1 {
+  font-size: 1em;
+  margin: 1em;
+  padding: 0.25em 1em;
+  border-radius: 3px;
+  color: mediumseagreen;
+  border: 2px solid mediumseagreen;
+}
+
+<div>
+  <styled.button
+    theme={
+      {
+        "main": "palevioletred",
+      }
+    }
+  >
+    <button
+      className="c0"
+    >
+      Normal
+    </button>
+  </styled.button>
+  <Component
+    theme={
+      {
+        "main": "mediumseagreen",
+      }
+    }
+  >
+    <styled.button
+      theme={
+        {
+          "main": "palevioletred",
+        }
+      }
+    >
+      <button
+        className="c1"
+      >
+        Themed
+      </button>
+    </styled.button>
+  </Component>
+</div>
+`;
+
+exports[`theming > react-test-renderer 1`] = `
+.c0 {
+  font-size: 1em;
+  margin: 1em;
+  padding: 0.25em 1em;
+  border-radius: 3px;
+  color: palevioletred;
+  border: 2px solid palevioletred;
+}
+
+.c1 {
+  font-size: 1em;
+  margin: 1em;
+  padding: 0.25em 1em;
+  border-radius: 3px;
+  color: mediumseagreen;
+  border: 2px solid mediumseagreen;
+}
+
+<div>
+  <button
+    className="c0"
+  >
+    Normal
+  </button>
+  <button
+    className="c1"
+  >
+    Themed
+  </button>
+</div>
+`;
+
+exports[`theming > react-testing-library 1`] = `
+.c0 {
+  font-size: 1em;
+  margin: 1em;
+  padding: 0.25em 1em;
+  border-radius: 3px;
+  color: palevioletred;
+  border: 2px solid palevioletred;
+}
+
+.c1 {
+  font-size: 1em;
+  margin: 1em;
+  padding: 0.25em 1em;
+  border-radius: 3px;
+  color: mediumseagreen;
+  border: 2px solid mediumseagreen;
+}
+
+<div>
+  <button
+    class="c0"
+  >
+    Normal
+  </button>
+  <button
+    class="c1"
+  >
+    Themed
+  </button>
+</div>
+`;
+
+exports[`theming > shallow 1`] = `
+<div>
+  <styled.button
+    theme={
+      {
+        "main": "palevioletred",
+      }
+    }
+  >
+    Normal
+  </styled.button>
+  <Component
+    theme={
+      {
+        "main": "mediumseagreen",
+      }
+    }
+  >
+    <styled.button
+      theme={
+        {
+          "main": "palevioletred",
+        }
+      }
+    >
+      Themed
+    </styled.button>
+  </Component>
+</div>
+`;
+
+exports[`trailing white spaces > mount 1`] = `
+.c0 {
+  color: red;
+}
+
+<styled.div>
+  <div
+    className="c0 div  "
+  />
+</styled.div>
+`;
+
+exports[`trailing white spaces > react-test-renderer 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  className="c0 div  "
+/>
+`;
+
+exports[`trailing white spaces > react-testing-library 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  class="c0 div  "
+/>
+`;
+
+exports[`trailing white spaces > shallow 1`] = `
+.c0 {
+  color: red;
+}
+
+<div
+  className="c0 div  "
+/>
+`;

--- a/test/setup_vitest.js
+++ b/test/setup_vitest.js
@@ -1,0 +1,6 @@
+import { configure } from "enzyme";
+import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
+
+import "../vitest";
+
+configure({ adapter: new Adapter() });

--- a/test/styleSheetSerializer.vitest.jsx
+++ b/test/styleSheetSerializer.vitest.jsx
@@ -1,0 +1,429 @@
+import { render } from "@testing-library/react";
+import { mount, shallow } from "enzyme";
+import React from "react";
+import renderer from "react-test-renderer";
+import styled, { ThemeContext, ThemeProvider } from "styled-components";
+import prettyFormat, { plugins } from "pretty-format";
+import { setStyleSheetSerializerOptions } from "../serializer";
+import styleSheetSerializer from "../src/styleSheetSerializer";
+import { expect, it } from "vitest";
+
+const toMatchSnapshot = (component) => {
+  expect(renderer.create(component).toJSON()).toMatchSnapshot(
+    "react-test-renderer"
+  );
+  expect(shallow(component)).toMatchSnapshot("shallow");
+  expect(mount(component)).toMatchSnapshot("mount");
+  expect(render(component).container.firstChild).toMatchSnapshot(
+    "react-testing-library"
+  );
+};
+
+const shallowWithTheme = (tree, theme) => {
+  // this is terrible but couldn't figure out how to do it properly within the framework of enzyme
+  ThemeContext._currentValue = theme;
+
+  return shallow(tree);
+};
+
+/**
+ * Serializes a value similarly to jest-snapshot
+ *
+ * Imitates the serialization logic inside jest-snapshot,
+ * so we can pass options, including indent, to it.
+ *
+ * @see https://github.com/facebook/jest/blob/615084195ae1ae61ddd56162c62bbdda17587569/packages/jest-snapshot/src/utils.ts#L155-L163
+ * @see https://github.com/facebook/jest/blob/615084195ae1ae61ddd56162c62bbdda17587569/packages/jest-snapshot/src/plugins.ts#L24-L32
+ */
+const serialize = (val, indent = 2) =>
+  prettyFormat(val, {
+    escapeRegex: true,
+    indent,
+    plugins: [
+      styleSheetSerializer,
+      plugins.ReactTestComponent,
+      plugins.ReactElement,
+      plugins.DOMElement,
+      plugins.DOMCollection,
+      plugins.Immutable,
+      plugins.AsymmetricMatcher,
+    ],
+    printFunctionName: false,
+  });
+
+it("null", () => {
+  expect(null).toMatchSnapshot();
+});
+
+it("non-styled", () => {
+  toMatchSnapshot(<div />);
+});
+
+it("empty style", () => {
+  const Component = styled.div``;
+
+  toMatchSnapshot(<Component />);
+});
+
+it("duplicated components", () => {
+  const A = styled.div`
+    color: red;
+  `;
+  const B = styled.div`
+    color: green;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <A /> <A /> <B />
+    </div>
+  );
+});
+
+it("basic", () => {
+  const Wrapper = styled.section`
+    padding: 4em;
+    background: papayawhip;
+  `;
+
+  const Title = styled.h1`
+    font-size: 1.5em;
+    text-align: center;
+    color: palevioletred;
+  `;
+
+  toMatchSnapshot(
+    <Wrapper>
+      <Title>Hello World, this is my first styled component!</Title>
+    </Wrapper>
+  );
+});
+
+it("any component", () => {
+  const Link = ({ className, children }) => (
+    <a className={className}>{children}</a>
+  );
+
+  const StyledLink = styled(Link)`
+    color: palevioletred;
+    font-weight: bold;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <Link>Unstyled, boring Link</Link>
+      <br />
+      <StyledLink>Styled, exciting Link</StyledLink>
+    </div>
+  );
+});
+
+it("attaching additional props", () => {
+  const Div = styled.div.attrs(() => ({
+    className: "div",
+  }))`
+    color: red;
+  `;
+
+  toMatchSnapshot(<Div />);
+});
+
+it("leading white spaces", () => {
+  const Div = () => <div className="  div" />;
+
+  toMatchSnapshot(<Div />);
+});
+
+it("trailing white spaces", () => {
+  const Div = styled.div.attrs(() => ({
+    className: "div  ",
+  }))`
+    color: red;
+  `;
+
+  toMatchSnapshot(<Div />);
+});
+
+it("included class name", () => {
+  const Div = styled.div.attrs(() => ({
+    className: "i",
+  }))`
+    color: red;
+  `;
+
+  toMatchSnapshot(<Div />);
+});
+
+it("theming", () => {
+  const Button = styled.button`
+    font-size: 1em;
+    margin: 1em;
+    padding: 0.25em 1em;
+    border-radius: 3px;
+
+    color: ${(props) => props.theme.main};
+    border: 2px solid ${(props) => props.theme.main};
+  `;
+
+  Button.defaultProps = {
+    theme: {
+      main: "palevioletred",
+    },
+  };
+
+  const theme = {
+    main: "mediumseagreen",
+  };
+
+  toMatchSnapshot(
+    <div>
+      <Button>Normal</Button>
+      <ThemeProvider theme={theme}>
+        <Button>Themed</Button>
+      </ThemeProvider>
+    </div>
+  );
+});
+
+it("shallow with theme", () => {
+  const Button = styled.button`
+    color: ${(props) => props.theme.main};
+  `;
+
+  const theme = {
+    main: "mediumseagreen",
+  };
+
+  const wrapper = shallowWithTheme(<Button>Themed</Button>, theme);
+
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("supported css", () => {
+  const Example = styled.div`
+    padding: 2em 1em;
+    background: papayawhip;
+
+    &:hover {
+      background: palevioletred;
+    }
+
+    @media (max-width: 600px) {
+      background: tomato;
+
+      &:hover {
+        background: yellow;
+      }
+    }
+
+    > p {
+      text-decoration: underline;
+    }
+
+    html.test & {
+      display: none;
+    }
+  `;
+
+  toMatchSnapshot(
+    <Example>
+      <p>Hello World!</p>
+    </Example>
+  );
+});
+
+it("referring to other components", () => {
+  const Link = styled.a`
+    display: flex;
+    align-items: center;
+    padding: 5px 10px;
+    background: papayawhip;
+    color: palevioletred;
+  `;
+
+  const Icon = styled.svg`
+    transition: fill 0.25s;
+    width: 48px;
+    height: 48px;
+
+    ${Link}:hover & {
+      fill: rebeccapurple;
+    }
+  `;
+
+  const Label = styled.span`
+    display: flex;
+    align-items: center;
+    line-height: 1.2;
+
+    &::before {
+      content: "◀";
+      margin: 0 10px;
+    }
+  `;
+
+  const Container = styled.div`
+    color: black;
+  `;
+  const TextWithConditionalFormatting = styled.span`
+    ${Container} & {
+      color: yellow;
+      background-color: ${(props) => (props.error ? "red" : "green")};
+    }
+  `;
+
+  const component = (
+    <Container>
+      <Link href="#">
+        <Icon />
+        <Label>Hovering my parent changes my style!</Label>
+        <TextWithConditionalFormatting>
+          I should be green
+        </TextWithConditionalFormatting>
+        <TextWithConditionalFormatting error>
+          I should be red
+        </TextWithConditionalFormatting>
+      </Link>
+    </Container>
+  );
+
+  expect(renderer.create(component).toJSON()).toMatchSnapshot(
+    "react-test-renderer"
+  );
+  expect(mount(component)).toMatchSnapshot("mount");
+  expect(render(component).container.firstChild).toMatchSnapshot(
+    "react-testing-library"
+  );
+});
+
+it("strips unused styles", () => {
+  const BlueText = styled.div`
+    color: blue;
+  `;
+  const RedText = styled.div`
+    color: red;
+  `;
+
+  const FancyText = styled.div`
+    font-size: 16px;
+
+    ${BlueText} {
+      text-align: right;
+    }
+    ${RedText} {
+      text-align: center;
+    }
+  `;
+
+  const component = (
+    <FancyText>
+      <BlueText>A container that has styles for an unused child</BlueText>
+    </FancyText>
+  );
+
+  expect(renderer.create(component).toJSON()).toMatchSnapshot(
+    "react-test-renderer"
+  );
+  expect(mount(component)).toMatchSnapshot("mount");
+  expect(render(component).container.firstChild).toMatchSnapshot(
+    "react-testing-library"
+  );
+});
+
+it("referring to other unreferenced components", () => {
+  const UnreferencedLink = styled.a`
+    font-size: 1.5em;
+  `;
+
+  const ReferencedLink = styled(UnreferencedLink)`
+    color: palevioletred;
+    font-weight: bold;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <ReferencedLink>Styled, exciting Link</ReferencedLink>
+    </div>
+  );
+});
+
+it("should match the same snapshot rerendering the same element", () => {
+  const StyledDiv = styled.div`
+    color: palevioletred;
+    font-weight: bold;
+  `;
+
+  const { rerender, container } = render(<StyledDiv />);
+
+  expect(container).toMatchSnapshot("first-render");
+  rerender(<StyledDiv />);
+  expect(container).toMatchSnapshot("second-render");
+});
+
+it("allows to disable css snapshotting", () => {
+  setStyleSheetSerializerOptions({ addStyles: false });
+  const A = styled.div`
+    color: red;
+  `;
+  const B = styled.div`
+    color: red;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <A>Styled, exciting div</A>
+      <B>Styled, exciting div</B>
+    </div>
+  );
+});
+
+it("allows to set a css classNameFormatter", () => {
+  setStyleSheetSerializerOptions({
+    classNameFormatter: (index) => `styledComponent${index}`,
+  });
+  const A = styled.div`
+    color: red;
+  `;
+  const B = styled.div`
+    color: green;
+  `;
+
+  toMatchSnapshot(
+    <div>
+      <A>Styled, exciting div</A>
+      <B>Styled, exciting div</B>
+    </div>
+  );
+});
+
+it("responds to indent configuration", () => {
+  const Link = styled.a`
+    color: blue;
+  `;
+
+  const mounted = renderer.create(<Link>Styled, exciting Link</Link>);
+
+  expect(serialize(mounted)).toMatchInlineSnapshot(`
+    ".c0 {
+      color: blue;
+    }
+
+    <a
+      className="c0"
+    >
+      Styled, exciting Link
+    </a>"
+  `);
+
+  expect(serialize(mounted, 0)).toMatchInlineSnapshot(`
+    ".c0 {
+    color: blue;
+    }
+
+    <a
+    className="c0"
+    >
+    Styled, exciting Link
+    </a>"
+  `);
+});

--- a/vitest.js
+++ b/vitest.js
@@ -1,0 +1,10 @@
+import { beforeEach, expect } from "vitest";
+
+const styleSheetSerializer = require("./src/styleSheetSerializer");
+const init = require("./src/init");
+
+init(beforeEach, expect);
+
+module.exports = {
+  styleSheetSerializer,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,6 +2101,136 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
   integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
 
+"@esbuild/aix-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
+  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
+
+"@esbuild/android-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
+  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
+
+"@esbuild/android-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
+  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
+
+"@esbuild/android-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
+  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
+
+"@esbuild/darwin-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz#6af6bb1d05887dac515de1b162b59dc71212ed76"
+  integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
+
+"@esbuild/darwin-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
+  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
+
+"@esbuild/freebsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
+  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
+
+"@esbuild/freebsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
+  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
+
+"@esbuild/linux-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
+  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
+
+"@esbuild/linux-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
+  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
+
+"@esbuild/linux-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
+  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
+
+"@esbuild/linux-loong64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
+  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
+
+"@esbuild/linux-mips64el@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
+  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
+
+"@esbuild/linux-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
+  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
+
+"@esbuild/linux-riscv64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
+  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
+
+"@esbuild/linux-s390x@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
+  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
+
+"@esbuild/linux-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
+  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
+
+"@esbuild/netbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
+  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
+
+"@esbuild/netbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
+  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
+
+"@esbuild/openbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
+  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
+
+"@esbuild/openbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
+  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
+
+"@esbuild/openharmony-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
+  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
+
+"@esbuild/sunos-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
+  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
+
+"@esbuild/win32-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
+  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
+
+"@esbuild/win32-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
+  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
+
+"@esbuild/win32-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
+  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
+
 "@eslint/eslintrc@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.4.tgz#dfe0ff7ba270848d10c5add0715e04964c034b31"
@@ -2369,6 +2499,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz#f8a3249862f91be48d3127c3cfe992f79b4b8811"
@@ -2536,6 +2671,116 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
+"@rollup/rollup-android-arm-eabi@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz#7050c2acdc1214a730058e21f613ab0e1fe1ced9"
+  integrity sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==
+
+"@rollup/rollup-android-arm64@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz#3f5b2afbfcbe9021649701cf6ff0d54b1fb7e4a5"
+  integrity sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==
+
+"@rollup/rollup-darwin-arm64@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz#70a1679fb4393ba7bafb730ee56a5278cbcdafb0"
+  integrity sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==
+
+"@rollup/rollup-darwin-x64@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz#ae75aec88fa72069de9bca3a3ec22bf4e6a962bf"
+  integrity sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==
+
+"@rollup/rollup-freebsd-arm64@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz#8a2bda997faa1d7e335ce1961ce71d1a76ac6288"
+  integrity sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==
+
+"@rollup/rollup-freebsd-x64@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz#fc287bcc39b9a9c0df97336d68fd5f4458f87977"
+  integrity sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz#5b5a2a55dffaa64d7c7a231e80e491219e33d4f3"
+  integrity sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==
+
+"@rollup/rollup-linux-arm-musleabihf@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz#979eab95003c21837ea0fdd8a721aa3e69fa4aa3"
+  integrity sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==
+
+"@rollup/rollup-linux-arm64-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz#53b89f1289cbeca5ed9b6ca1602a6fe1a29dd4e2"
+  integrity sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==
+
+"@rollup/rollup-linux-arm64-musl@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz#3bbcf5e13c09d0c4c55bd9c75ec6a7aeee56fe28"
+  integrity sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==
+
+"@rollup/rollup-linux-loong64-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz#1cc71838465a8297f92ccc5cc9c29756b71f6e73"
+  integrity sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==
+
+"@rollup/rollup-linux-ppc64-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz#fe3fdf2ef57dc2d58fedd4f1e0678660772c843a"
+  integrity sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==
+
+"@rollup/rollup-linux-riscv64-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz#eebc99e75832891d58532501879ca749b1592f93"
+  integrity sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==
+
+"@rollup/rollup-linux-riscv64-musl@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz#9a2df234d61763a44601eba17c36844a18f20539"
+  integrity sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==
+
+"@rollup/rollup-linux-s390x-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz#f0e45ea7e41ee473c85458b1ec8fab9572cc1834"
+  integrity sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==
+
+"@rollup/rollup-linux-x64-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz#ed63dec576799fa5571eee5b2040f65faa82b49b"
+  integrity sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==
+
+"@rollup/rollup-linux-x64-musl@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz#755c56ac79b17fbdf0359bce7e2293a11de30ad0"
+  integrity sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==
+
+"@rollup/rollup-openharmony-arm64@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz#84b4170fe28c2b41e406add6ccf8513bf91195ea"
+  integrity sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==
+
+"@rollup/rollup-win32-arm64-msvc@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz#4fb0cd004183da819bec804eba70f1ef6936ccbf"
+  integrity sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==
+
+"@rollup/rollup-win32-ia32-msvc@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz#1788ba80313477a31e6214390906201604ee38eb"
+  integrity sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==
+
+"@rollup/rollup-win32-x64-gnu@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz#867222f288a9557487900c7836998123ebbadc9d"
+  integrity sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==
+
+"@rollup/rollup-win32-x64-msvc@4.52.3":
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz#3f55b6e8fe809a7d29959d6bc686cce1804581f0"
+  integrity sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==
+
 "@sideway/address@^4.1.0":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
@@ -2632,12 +2877,29 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chai@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.2.tgz#6f14cea18180ffc4416bc0fd12be05fdd73bdd6b"
+  integrity sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==
+  dependencies:
+    "@types/deep-eql" "*"
+
 "@types/cheerio@^0.22.22":
   version "0.22.30"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.30.tgz#6c1ded70d20d890337f0f5144be2c5e9ce0936e6"
   integrity sha512-t7ZVArWZlq3dFa9Yt33qFBQIK4CQd1Q3UJp0V+UhP6vgLWLM6Qug7vZuRSGXg45zXeB1Fm5X2vmBkEX58LV2Tw==
   dependencies:
     "@types/node" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
+
+"@types/estree@1.0.8", "@types/estree@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
@@ -2744,6 +3006,67 @@
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@vitest/expect@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.4.tgz#8362124cd811a5ee11c5768207b9df53d34f2433"
+  integrity sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.4.tgz#4471c4efbd62db0d4fa203e65cc6b058a85cabd3"
+  integrity sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==
+  dependencies:
+    "@vitest/spy" "3.2.4"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.2.4", "@vitest/pretty-format@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.4.tgz#3c102f79e82b204a26c7a5921bf47d534919d3b4"
+  integrity sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.4.tgz#5ce0274f24a971f6500f6fc166d53d8382430766"
+  integrity sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==
+  dependencies:
+    "@vitest/utils" "3.2.4"
+    pathe "^2.0.3"
+    strip-literal "^3.0.0"
+
+"@vitest/snapshot@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.4.tgz#40a8bc0346ac0aee923c0eefc2dc005d90bc987c"
+  integrity sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==
+  dependencies:
+    "@vitest/pretty-format" "3.2.4"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.4.tgz#cc18f26f40f3f028da6620046881f4e4518c2599"
+  integrity sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==
+  dependencies:
+    tinyspy "^4.0.3"
+
+"@vitest/utils@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.4.tgz#c0813bc42d99527fb8c5b138c7a88516bca46fea"
+  integrity sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==
+  dependencies:
+    "@vitest/pretty-format" "3.2.4"
+    loupe "^3.1.4"
+    tinyrainbow "^2.0.0"
 
 "@wojtekmaj/enzyme-adapter-react-17@^0.6.5":
   version "0.6.5"
@@ -3032,6 +3355,11 @@ asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -3412,6 +3740,11 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -3491,6 +3824,17 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
+chai@^5.2.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -3520,6 +3864,11 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+check-error@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.1.tgz#87eb876ae71ee388fa0471fe423f494be1d96ccc"
+  integrity sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==
 
 cheerio-select@^1.5.0:
   version "1.5.0"
@@ -3964,6 +4313,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   dependencies:
     ms "2.1.2"
 
+debug@^4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -3983,6 +4339,11 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
@@ -4288,6 +4649,11 @@ es-array-method-boxes-properly@^1.0.0:
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-to-primitive@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
@@ -4296,6 +4662,38 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+esbuild@^0.25.0:
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.10.tgz#37f5aa5cd14500f141be121c01b096ca83ac34a9"
+  integrity sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.25.10"
+    "@esbuild/android-arm" "0.25.10"
+    "@esbuild/android-arm64" "0.25.10"
+    "@esbuild/android-x64" "0.25.10"
+    "@esbuild/darwin-arm64" "0.25.10"
+    "@esbuild/darwin-x64" "0.25.10"
+    "@esbuild/freebsd-arm64" "0.25.10"
+    "@esbuild/freebsd-x64" "0.25.10"
+    "@esbuild/linux-arm" "0.25.10"
+    "@esbuild/linux-arm64" "0.25.10"
+    "@esbuild/linux-ia32" "0.25.10"
+    "@esbuild/linux-loong64" "0.25.10"
+    "@esbuild/linux-mips64el" "0.25.10"
+    "@esbuild/linux-ppc64" "0.25.10"
+    "@esbuild/linux-riscv64" "0.25.10"
+    "@esbuild/linux-s390x" "0.25.10"
+    "@esbuild/linux-x64" "0.25.10"
+    "@esbuild/netbsd-arm64" "0.25.10"
+    "@esbuild/netbsd-x64" "0.25.10"
+    "@esbuild/openbsd-arm64" "0.25.10"
+    "@esbuild/openbsd-x64" "0.25.10"
+    "@esbuild/openharmony-arm64" "0.25.10"
+    "@esbuild/sunos-x64" "0.25.10"
+    "@esbuild/win32-arm64" "0.25.10"
+    "@esbuild/win32-ia32" "0.25.10"
+    "@esbuild/win32-x64" "0.25.10"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -4470,6 +4868,13 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -4535,6 +4940,11 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+expect-type@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
+  integrity sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==
 
 expect@^27.3.1:
   version "27.3.1"
@@ -4603,6 +5013,11 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -4762,7 +5177,7 @@ fsevents@^2.1.2, fsevents@^2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -5979,6 +6394,11 @@ joi@^17.2.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
+
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -6302,6 +6722,11 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -6320,6 +6745,13 @@ lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
+magic-string@^0.30.17:
+  version "0.30.19"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.19.tgz#cebe9f104e565602e5d2098c5f2e79a77cc86da9"
+  integrity sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -6731,6 +7163,16 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 nanoid@^3.3.6:
   version "3.3.6"
@@ -7184,6 +7626,16 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -7194,6 +7646,11 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -7203,6 +7660,11 @@ picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+picomatch@^4.0.2, picomatch@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
 pify@^4.0.1:
   version "4.0.1"
@@ -7270,6 +7732,15 @@ postcss@^8.4.23:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.5.6:
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
+  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 preact-render-to-json@^3.6.6:
   version "3.6.6"
@@ -7764,6 +8235,37 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rollup@^4.43.0:
+  version "4.52.3"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.52.3.tgz#cc5c28d772b022ce48b235a97b347ccd9d88c1a3"
+  integrity sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.52.3"
+    "@rollup/rollup-android-arm64" "4.52.3"
+    "@rollup/rollup-darwin-arm64" "4.52.3"
+    "@rollup/rollup-darwin-x64" "4.52.3"
+    "@rollup/rollup-freebsd-arm64" "4.52.3"
+    "@rollup/rollup-freebsd-x64" "4.52.3"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.52.3"
+    "@rollup/rollup-linux-arm-musleabihf" "4.52.3"
+    "@rollup/rollup-linux-arm64-gnu" "4.52.3"
+    "@rollup/rollup-linux-arm64-musl" "4.52.3"
+    "@rollup/rollup-linux-loong64-gnu" "4.52.3"
+    "@rollup/rollup-linux-ppc64-gnu" "4.52.3"
+    "@rollup/rollup-linux-riscv64-gnu" "4.52.3"
+    "@rollup/rollup-linux-riscv64-musl" "4.52.3"
+    "@rollup/rollup-linux-s390x-gnu" "4.52.3"
+    "@rollup/rollup-linux-x64-gnu" "4.52.3"
+    "@rollup/rollup-linux-x64-musl" "4.52.3"
+    "@rollup/rollup-openharmony-arm64" "4.52.3"
+    "@rollup/rollup-win32-arm64-msvc" "4.52.3"
+    "@rollup/rollup-win32-ia32-msvc" "4.52.3"
+    "@rollup/rollup-win32-x64-gnu" "4.52.3"
+    "@rollup/rollup-win32-x64-msvc" "4.52.3"
+    fsevents "~2.3.2"
+
 rst-selector-parser@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
@@ -7982,6 +8484,11 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
@@ -8081,6 +8588,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -8139,6 +8651,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
@@ -8163,6 +8680,11 @@ static-extend@^0.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+std-env@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
+  integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
 
 stream-buffers@2.2.x:
   version "2.2.0"
@@ -8272,6 +8794,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-literal@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.1.0.tgz#222b243dd2d49c0bcd0de8906adbd84177196032"
+  integrity sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==
+  dependencies:
+    js-tokens "^9.0.1"
 
 styled-components@^6.0.9:
   version "6.0.9"
@@ -8406,6 +8935,39 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinyglobby@^0.2.14, tinyglobby@^0.2.15:
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
+  integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.4.tgz#d77a002fb53a88aa1429b419c1c92492e0c81f78"
+  integrity sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -8690,6 +9252,60 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.1"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.1.7.tgz#ed3f9f06e21d6574fe1ad425f6b0912d027ffc13"
+  integrity sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==
+  dependencies:
+    esbuild "^0.25.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.4.tgz#0637b903ad79d1539a25bc34c0ed54b5c67702ea"
+  integrity sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/expect" "3.2.4"
+    "@vitest/mocker" "3.2.4"
+    "@vitest/pretty-format" "^3.2.4"
+    "@vitest/runner" "3.2.4"
+    "@vitest/snapshot" "3.2.4"
+    "@vitest/spy" "3.2.4"
+    "@vitest/utils" "3.2.4"
+    chai "^5.2.0"
+    debug "^4.4.1"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    picomatch "^4.0.2"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.14"
+    tinypool "^1.1.1"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node "3.2.4"
+    why-is-node-running "^2.3.0"
+
 vlq@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.1.tgz#c003f6e7c0b4c1edd623fd6ee50bbc0d6a1de468"
@@ -8806,6 +9422,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.5"


### PR DESCRIPTION
Following #431 and https://github.com/styled-components/jest-styled-components/issues/431#issuecomment-3352062225

I used the same technique as [@testing-library/jest-dom](https://github.com/testing-library/jest-dom/blob/95f870acb2f9b200bb8833aba476fba3ad7b8dee/vitest.js)

We can import `jest-styled-components/vitest` and it does the trick.